### PR TITLE
Cleaned up minor textual errors

### DIFF
--- a/design/prototype_condor_sgm.py
+++ b/design/prototype_condor_sgm.py
@@ -262,7 +262,7 @@ class MyTrajectory(TrajectoryModel):
     model = some_ode_class # not sure if this is an API or convention
 
     # add outputs that depend on either integral or terminal terms
-    integrand_term.output1 = ... #some expressin
+    integrand_term.output1 = ... #some expressing
     terminal_term.output2 = ... # some expression
 
     # or both

--- a/design/prototype_condor_sgm.py
+++ b/design/prototype_condor_sgm.py
@@ -250,7 +250,7 @@ class AircraftMission(SGM):
 class trajectory_analysis(model=some_ode_class,):
     class output1(output):
         integrand_cost = expression(model.state, control, etc)
-        terminal_cost = expressino(...)
+        terminal_cost = expression(...)
 
     input = ....
     model.p = input

--- a/design/prototype_condor_sgm.py
+++ b/design/prototype_condor_sgm.py
@@ -26,7 +26,7 @@ class BaseLinCovCW:
     # can create state rate from overloading simupy but can't inherently inspect
     # interior signals, only IO which is very systems-y. May need symbolic vector to
     # dispatch operations? neat.
-    # neeed to automate passing up of metadata from a simupy bd -- 
+    # need to automate passing up of metadata from a simupy bd -- 
     # similar system output as attribute dict with state keysa, ?? o
     # can't have computational blocks?? unless they provide a derivative?
     # need to create own symbolic representation 

--- a/docs/howto_src/table_basics.py
+++ b/docs/howto_src/table_basics.py
@@ -7,7 +7,7 @@ Tabular Data
 # %%
 # It is often useful to interpolate pre-existing data. For this, the
 # :class:`~condor.contrib.TableLookup` model provides a convenient way to specify the
-# interpolant input and output data. This model also provids an example of using a
+# interpolant input and output data. This model also provides an example of using a
 # :class:`~condor.contrib.ExternalSolverWrapper` by wrapping  uses the `ndsplines
 # <https://ndsplines.readthedocs.io/>`_ library to perform the interpolation and
 # compute derivatives as needed for tensor-product B-splines.  Note that this table

--- a/docs/tutorial_src/polar_transform.py
+++ b/docs/tutorial_src/polar_transform.py
@@ -27,7 +27,7 @@ class PolarTransform(co.ExplicitSystem):
 
 
 # %%
-# In general, once you've defined any system in Condor, you can just evaulate it
+# In general, once you've defined any system in Condor, you can just evaluate it
 # numerically by passing in numbers:
 
 p = PolarTransform(x=3, y=4)

--- a/examples/LinCovCW.py
+++ b/examples/LinCovCW.py
@@ -83,7 +83,7 @@ class LinCovCW(co.ODESystem):
     dot[C] = Fcal @ C + C @ Fcal.T + Cov_prop_offset
     dot[tt] = 1.
 
-    # TODO: in generla case, this should be a dfhat/dx(hat) instead of exact Acw
+    # TODO: in general case, this should be a dfhat/dx(hat) instead of exact Acw
     # and should be reflected in bottom right corner of Fcal as well
     dot[P] = Acw @ P + P @ Acw.T + P_prop_offset
 

--- a/examples/orbital_1.py
+++ b/examples/orbital_1.py
@@ -212,7 +212,7 @@ class TotalDeltaV(co.OptimizationProblem):
     # inheritance... I suppose the originally Hohmann model could easily be written to
     # include more parameters to solve all permutations of this problem... weights for
     # each output, upper bounds for each output (and combinations?)
-    # what about including a default for a paremter at a model level? no, just make a
+    # what about including a default for a parameter at a model level? no, just make a
     # dict like unbounded_kwargs to fill in with a large number/inf
     pos_disp_max = parameter()
     constraint(sim.final_pos_disp-pos_disp_max, upper_bound=0.)

--- a/examples/orbital_3.py
+++ b/examples/orbital_3.py
@@ -80,7 +80,7 @@ class LinCovCW(co.ODESystem):
     dot[C] = Fcal @ C + C @ Fcal.T + Cov_prop_offset
     dot[tt] = 1.
 
-    # TODO: in generla case, this should be a dfhat/dx(hat) instead of exact Acw
+    # TODO: in general case, this should be a dfhat/dx(hat) instead of exact Acw
     # and should be reflected in bottom right corner of Fcal as well
     dot[P] = Acw @ P + P @ Acw.T + P_prop_offset
 

--- a/examples/upcycle/high_bypass_turbofan.py
+++ b/examples/upcycle/high_bypass_turbofan.py
@@ -25,7 +25,7 @@ class HBTF(pyc.Cycle):
 
 
     def setup(self):
-        #Setup the problem by including all the relavant components here - comp, burner, turbine etc
+        #Setup the problem by including all the relevant components here - comp, burner, turbine etc
         
         #Create any relavent short hands here:
         design = self.options['design']

--- a/examples/upcycle/high_bypass_turbofan.py
+++ b/examples/upcycle/high_bypass_turbofan.py
@@ -101,7 +101,7 @@ class HBTF(pyc.Cycle):
         #Create a balance component
         # Balances can be a bit confusing, here's some explanation -
         #   State Variables:
-        #           (W)        Inlet mass flow rate to implictly balance thrust
+        #           (W)        Inlet mass flow rate to implicitly balance thrust
         #                      LHS: perf.Fn  == RHS: Thrust requirement (set when TF is instantiated)
         #
         #           (FAR)      Fuel-air ratio to balance Tt4

--- a/examples/upcycle/high_bypass_turbofan.py
+++ b/examples/upcycle/high_bypass_turbofan.py
@@ -27,7 +27,7 @@ class HBTF(pyc.Cycle):
     def setup(self):
         #Setup the problem by including all the relevant components here - comp, burner, turbine etc
         
-        #Create any relavent short hands here:
+        #Create any relevant short hands here:
         design = self.options['design']
         
         USE_TABULAR = True

--- a/examples/upcycle/high_bypass_turbofan.py
+++ b/examples/upcycle/high_bypass_turbofan.py
@@ -94,7 +94,7 @@ class HBTF(pyc.Cycle):
         #HP-shaft connections
         self.connect('hpc.trq', 'hp_shaft.trq_0')
         self.connect('hpt.trq', 'hp_shaft.trq_1')
-        #Ideally expanding flow by conneting flight condition static pressure to nozzle exhaust pressure
+        #Ideally expanding flow by connecting flight condition static pressure to nozzle exhaust pressure
         self.connect('fc.Fl_O:stat:P', 'core_nozz.Ps_exhaust')
         self.connect('fc.Fl_O:stat:P', 'byp_nozz.Ps_exhaust')
         

--- a/examples/upcycle/high_bypass_turbofan.py
+++ b/examples/upcycle/high_bypass_turbofan.py
@@ -303,7 +303,7 @@ class MPhbtf(pyc.MPCycle):
 
     def setup(self):
 
-        self.pyc_add_pnt('DESIGN', HBTF(thermo_method='TABULAR')) # Create an instace of the High Bypass ratio Turbofan
+        self.pyc_add_pnt('DESIGN', HBTF(thermo_method='TABULAR')) # Create an instance of the High Bypass ratio Turbofan
 
         self.set_input_defaults('DESIGN.inlet.MN', 0.751)
         self.set_input_defaults('DESIGN.fan.MN', 0.4578)

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -108,7 +108,7 @@ a submodel template: inherit SubmodelTemplate
 primary to a template, define fields and pre-loaded symbols
 
 a user model: inherit from a template
-"read" user-defined elements, including output from embeded models
+"read" user-defined elements, including output from embedded models
 inherit user-copies of fields, prepare to be be runnable -- substitue placeholder
 elements with their subs (or defaults)
 copy & extend any submodel templates

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -66,7 +66,7 @@ user model creation
     (python )inherit methods for binding, accessing IO data, etc.--not part of class creation
 
 
-so __prepare__ has to handle all the accesible element and field injection (accessing/copying/etc), 
+so __prepare__ has to handle all the accessible element and field injection (accessing/copying/etc), 
 CondorClassDict has to handle assignment for elements/submodels/etc
 __new__ is cleanup of standard class attributes before passing to type().__new__ and
 finalization after -- I guess it's possible the finalization could happen in __init__ or

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -48,7 +48,7 @@ submodel template:
     extension?? kwargs need to be optional, then just another layer of dispatch.
 
 assembly/component model template:
-    specify rules for acceptable child/parent (but also methods for later modificaiton)
+    specify rules for acceptable child/parent (but also methods for later modification)
     template extension classes by default 
 
 user assembly/component model creation:

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -109,7 +109,7 @@ primary to a template, define fields and pre-loaded symbols
 
 a user model: inherit from a template
 "read" user-defined elements, including output from embedded models
-inherit user-copies of fields, prepare to be be runnable -- substitue placeholder
+inherit user-copies of fields, prepare to be be runnable -- substitute placeholder
 elements with their subs (or defaults)
 copy & extend any submodel templates
 

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -159,7 +159,7 @@ __new__ is:
 
   final bind fields
   process inheriting submodel templates
-  if implementaiton exists
+  if implementation exists
       create input field dataclasses (why not earlier??)
       bind implementation
       bind dataclasses (attach qualname etc)

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -17,7 +17,7 @@ from condor.models import Options
 ##################
 """
 ModelTemplate flag for user_model (default True)
-If false, can add placeholders, returns a tempalte instead of model
+If false, can add placeholders, returns a template instead of model
 
 
 

--- a/src/condor/__init__.py
+++ b/src/condor/__init__.py
@@ -72,7 +72,7 @@ __new__ is cleanup of standard class attributes before passing to type().__new__
 finalization after -- I guess it's possible the finalization could happen in __init__ or
 even __init_subclass__?
 
-customize meta so only have relevant attriburtes
+customize meta so only have relevant attributes
 too hard to use different metaclasses for base/template/user ? times special types like
 submodel, assemblycomponent.
 if template inherits from base, user inherits from template, what happens? special types

--- a/src/condor/backends/default.py
+++ b/src/condor/backends/default.py
@@ -85,7 +85,7 @@ casadi_implementations.ODESystem = 'a reference to check exists'
 import condor as co
 
 but probably should just figure out hooks to do that? Could create local dict of backend
-that gets updated with backend.implementations at the top of this file, then libary/user
+that gets updated with backend.implementations at the top of this file, then library/user
 code could update it (add/overwrite)
 """
 

--- a/src/condor/backends/element_mixin.py
+++ b/src/condor/backends/element_mixin.py
@@ -88,7 +88,7 @@ casadi_implementations.ODESystem = 'a reference to check exists'
 import condor as co
 
 but probably should just figure out hooks to do that? Could create local dict of backend
-that gets updated with backend.implementations at the top of this file, then libary/user
+that gets updated with backend.implementations at the top of this file, then library/user
 code could update it (add/overwrite)
 """
 

--- a/src/condor/backends/scipy/__init__.py
+++ b/src/condor/backends/scipy/__init__.py
@@ -247,7 +247,7 @@ def symbol_generator(name, n, m=1, symmetric=False, diagonal=0, dynamic=False, *
     ----------
     name : string
         Base name for variables; each variable is name_ij, which
-        admitedly only works clearly for n,m < 10
+        admittedly only works clearly for n,m < 10
     n : int
         Number of rows
     m : int

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -643,7 +643,7 @@ class TrajectoryAnalysis(
         # places embedded models came from -- I guess just events and modals?
 
 
-# TODO: need to exlcude fields, particularly dot, initial, etc.
+# TODO: need to exclude fields, particularly dot, initial, etc.
 # define which fields get lifted completely, which become "read only" (can't generate
 # new state) etc.
 # maybe allow creation of new parameters (into ODESystem parameter field), access to

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -710,7 +710,7 @@ class Event(
     extraneous implementation constructions.
     then when trajectory analysis is evaluated and bound, add events... somewhere. Maybe
     the _res.e elements get replaced by the evaluated Event models (so one for each
-    occurance of the event)??? function isn't necessary, so maybe get an index instead.
+    occurrence of the event)??? function isn't necessary, so maybe get an index instead.
 
     """
     # TODO: singleton field event.function is very similar to objective in

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -287,7 +287,7 @@ class ODESystem(ModelTemplate):
     """
 
     """
-    t - indepdendent variable of ODE, notionally time but can be used
+    t - independent variable of ODE, notionally time but can be used
     for anything. Used directly by subclasses (e.g., user code may use
     `u=DynamicsModel.t`, implementations will use this symbol
     directly for fields)

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -317,7 +317,7 @@ class ODESystem(ModelTemplate):
 
     I guess block diagram is nice for simulating something like saturation block --
     create event and switch modes? but I guess that's re-creatable with modes. But maybe
-    needs control/subsitution -- I guess what I'm calling "control" is really an
+    needs control/substitution -- I guess what I'm calling "control" is really an
     (explicit) algebraic state? I guess this is really the same as an "output" and is in
     fact how simupy implements it. maybe convert output to a freefield that takes an
     expression (like constraint, I guess?) and then "make" is only in mode and adds

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -872,7 +872,7 @@ class ExternalSolverWrapperType(ModelTemplateType):
         # gets called on instantiation of the user wrapper, so COULD return the
         # condor model instead of the wrapper class -- perhaps this is more condoric,
         # not sure what's preferable
-        # actully, this can get used instead of create model with init wrapper? no,
+        # actually, this can get used instead of create model with init wrapper? no,
         # don't have access to instance yet.
         # print(cls, "__call__")
         wrapper_object = super().__call__(*args, **kwargs)

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -585,7 +585,7 @@ class TrajectoryAnalysis(
     #: additional output calculated from the terminal state and/or integrand terms
     trajectory_output = TrajectoryOutputField()
     #: final time; may not be reached if the system has a terminating :class:`Event`
-    #: occuring before ``tf``
+    #: occurring before ``tf``
     tf = placeholder(default=np.inf)  # TODO use placeholder with default = None
     #: intitial time (default 0)
     t0 = placeholder(default=0.0)

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -292,7 +292,7 @@ class ODESystem(ModelTemplate):
     `u=DynamicsModel.t`, implementations will use this symbol
     directly for fields)
 
-    parameter - auxilary variables (constant-in-time) that determine system behavior
+    parameter - auxiliary variables (constant-in-time) that determine system behavior
 
     state - fully defines evolution of system driven by ODEs
 

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -394,7 +394,7 @@ class ODESystem(ModelTemplate):
 
     # TODO switch to scikits.odes, especially updating update function API to get an
     # array of length num_events w/ elements 0 for did not occur and +/-1 for direction
-    # don't use nan's to terminate? althogh, can't code-gen termination?
+    # don't use nan's to terminate? although, can't code-gen termination?
 
     # --> MAKE SURE scikits.odes is re-entrant. AND important TODO: figure out how to
     # create new implementation instances as needed for parallelization. Not sure if

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -412,7 +412,7 @@ class ODESystem(ModelTemplate):
 
     # TODO: currently, to get a discrete time control need to augment state and provide
     # a separate initializer, even though it's  generally going to be the same
-    # expression as the update. Should that be fixed in simupy? event funciton = 0 -> do
+    # expression as the update. Should that be fixed in simupy? event function = 0 -> do
     # update? I can fix it in casadi shooting_gradient_method.py as well.
 
     # or is initial where we want it? consistent with initial conition processing for

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -341,7 +341,7 @@ class ODESystem(ModelTemplate):
 
     """
 
-    # TODO: indepdent var  needs its own descriptor type? OR do we want user classes to do
+    # TODO: independent var  needs its own descriptor type? OR do we want user classes to do
     # t = DynamicsModel.independent_variable ? That would allow leaving it like this and
     # consumers still know what it is
     # or just set it to t and always use it? trying this way...

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -428,7 +428,7 @@ class ODESystem(ModelTemplate):
     # TODO: add event times/event channels to SimulationResult during detection
 
     # TODO: don't like hacks to simupy to make it work... especially the success
-    # checking stuff -- is that neccessary anymore?
+    # checking stuff -- is that necessary anymore?
 
     #: independent variable :math:`t`
     t = placeholder(default=None)

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -225,7 +225,7 @@ class OptimizationProblem(ModelTemplate, model_metaclass=OptimizationProblemType
             var = getattr(cls, k)
             if var.field_type is not cls.variable:
                 raise ValueError(
-                    "Use set initial to set the initialier for variables, attempting to set {k}"
+                    "Use set initial to set the initializer for variables, attempting to set {k}"
                 )
             var.initializer = v
 

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -454,7 +454,7 @@ class TrajectoryAnalysisMetaData(SubmodelMetaData):
 
 
 class TrajectoryAnalysisType(SubmodelType):
-    """Handle kwargs for including/excluding events (also need to include/exlcude
+    """Handle kwargs for including/excluding events (also need to include/exclude
         modes?), injecting bound events (event functions, updates) to model, etc.
 
         A common use case will be to bind the parameters then only update the state...

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -129,7 +129,7 @@ class AlgebraicSystem(ModelTemplate, model_metaclass=AlgebraicSystemType):
             var = getattr(cls, k)
             if var.field_type is not cls.variable:
                 raise ValueError(
-                    "Use set initial to set the initialier for variables, attempting to set {k}"
+                    "Use set initial to set the initializer for variables, attempting to set {k}"
                 )
             var.initializer = v
 

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -587,7 +587,7 @@ class TrajectoryAnalysis(
     #: final time; may not be reached if the system has a terminating :class:`Event`
     #: occurring before ``tf``
     tf = placeholder(default=np.inf)  # TODO use placeholder with default = None
-    #: intitial time (default 0)
+    #: initial time (default 0)
     t0 = placeholder(default=0.0)
 
     # TODO: how to make trajectory outputs that depend on other state's outputs without

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -388,7 +388,7 @@ class ODESystem(ModelTemplate):
     # TODO: does the simulation result need to be included in the template somehow?
     # Or is this an implementation detail and current approach is fine? Or how to
     # indicate that time, state, and output fields are time varying and should be
-    # written as an arrray and not to eg the database?
+    # written as an array and not to eg the database?
 
     # SimuPy-coupled TODO
 

--- a/src/condor/fields.py
+++ b/src/condor/fields.py
@@ -702,7 +702,7 @@ class AssignedField(Field, default_direction=Direction.output):
                 # TODO: I guess if this accepts model instances, it becomes recursive to
                 # allow dot access to sub systems? Actually, this breaks the idea of
                 # both system encapsolation and implementations. So don't do it, but
-                # document it. Can programatically add sub-system outputs though. For
+                # document it. Can programmatically add sub-system outputs though. For
                 # these reasons, ditch intermediate stuff.
                 **asdict(symbol_data),
             )

--- a/src/condor/fields.py
+++ b/src/condor/fields.py
@@ -56,7 +56,7 @@ class AnyTopeofModel(co....):
 # just literally promotes=*?
 
 
-# TODO defensive chek to make sure trajectory analysis doesn't over write odemodel
+# TODO defensive check to make sure trajectory analysis doesn't over write odemodel
 # dynamic output?
 # todo inner_to is only for ode system. should backref have a better name than
 # `inner_to`? Maybe even ODESystem....

--- a/src/condor/fields.py
+++ b/src/condor/fields.py
@@ -702,7 +702,7 @@ class AssignedField(Field, default_direction=Direction.output):
                 # TODO: I guess if this accepts model instances, it becomes recursive to
                 # allow dot access to sub systems? Actually, this breaks the idea of
                 # both system encapsolation and implementations. So don't do it, but
-                # doument it. Can programatically add sub-system outputs though. For
+                # document it. Can programatically add sub-system outputs though. For
                 # these reasons, ditch intermediate stuff.
                 **asdict(symbol_data),
             )

--- a/src/condor/fields.py
+++ b/src/condor/fields.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 # of creating input field elements to a super-system based on input field elements that
 # the sub-system require that aren't matching outputs of previous sub-systems (exact
 # name matching or define dictionary where key is current subsystem input name and value
-# is previous subsytem output name to connect) and
+# is previous subsystem output name to connect) and
 # want to do something like
 """
 class AnyTopeofModel(co....):

--- a/src/condor/implementations/__init__.py
+++ b/src/condor/implementations/__init__.py
@@ -21,7 +21,7 @@ import numpy as np
 # it
 
 # would like implementation to be the interface between model field and the callback,
-# but some of the helpers (eg initializer, state settter, etc) generate functions, not
+# but some of the helpers (eg initializer, state setter, etc) generate functions, not
 # just collect expressions.
 
 # TODO figure out how to use names for casadi callback layer

--- a/src/condor/implementations/iterative.py
+++ b/src/condor/implementations/iterative.py
@@ -260,7 +260,7 @@ class CasadiNlpsolImplementation(OptimizationProblem):
                 print_time=False,
                 ipopt=self.options,
                 # print_level = 0-2: nothing, 3-4: summary, 5: iter table (default)
-                # tol=1E-14, # tighter tol for sensitivty
+                # tol=1E-14, # tighter tol for sensitivity
                 # accept_every_trial_step="yes",
                 # max_iter=1000,
                 # constr_viol_tol=10.,

--- a/src/condor/implementations/sgm_trajectory.py
+++ b/src/condor/implementations/sgm_trajectory.py
@@ -187,7 +187,7 @@ class TrajectoryAnalysis:
                     if isinstance(at_time_start, symbol_class) or at_time_start != 0.0:
                         e_expr = e_expr * (model.t >= at_time_start)
                         # if there is a start offset, add a linear term to provide a
-                        # zero-crossing at first occurance
+                        # zero-crossing at first occurrence
                         pre_term = (at_time_start - model.t) * (
                             model.t <= at_time_start
                         )

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -1114,7 +1114,7 @@ class ModelType(BaseModelType):
         """perform placeholder substitution
 
         how to do an embedded model placeholder? use a deferred system to define? would
-        user models need to substitue, or would same basic mechanism work?
+        user models need to substitute, or would same basic mechanism work?
         """
         # process placeholders
         # TODO -- if default = None, keep it as a dummy variable

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -881,7 +881,7 @@ class ModelTemplateType(BaseModelType):
         if model_metaclass is not None:
             new_cls.user_model_metaclass = model_metaclass
             model_metaclass.baseclass_for_inheritance = new_cls
-            log.debug("processing for model metaclass asssigned, new")
+            log.debug("processing for model metaclass assigned, new")
 
         if as_template:
             impl = getattr(implementations, new_cls.__mro__[1].__name__, None)

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -1448,7 +1448,7 @@ ModelTemplateType.user_model_baseclass = Model
 Do we need class inheritance? "as_template" flag should suffice
 
 Case 1: defining a new model template -- very fiew fields, just copy and paste;
-manipulate and re-use implementaitons etc
+manipulate and re-use implementations etc
 
 Case 2: defining a new user model -- use sub-models or functions that perform
 declarative operations for you? Need to think about this, I guess it should be possible

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -1267,7 +1267,7 @@ class Model(metaclass=ModelType):
         if missing_args or extra_args:
             error_message = f"While calling {field._model.__class__.__name__}, "
             if extra_args:
-                error_message += f"recieved extra arguments: {extra_args}"
+                error_message += f"received extra arguments: {extra_args}"
             if extra_args and missing_args:
                 error_message += " and "
             if missing_args:

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -803,7 +803,7 @@ class ModelTemplateType(BaseModelType):
         cls, model_name, bases, as_template=False, model_metaclass=None, **kwargs
     ):
         if model_metaclass is not None:
-            log.debug("prcessing for model metaclass asssigned, prepare")
+            log.debug("processing for model metaclass asssigned, prepare")
         if cls.is_user_model(bases) and not as_template:
             log.debug(
                 "dispatch __prepare__ for user model %s, %s",

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -220,7 +220,7 @@ class Options:
     attribute to map the solver function [it could actually be the callable?
     scipy.minimize, lol sorry Kenny, you can change it after release once I'm bored]
     implementations dictionary needs to key on solver and be the arg/kwarg location for
-    the numeric callbacks (for this model/paramters) and a few other things like initial
+    the numeric callbacks (for this model/parameters) and a few other things like initial
     state. Current version is pretty close, hopefully
 
     Goal: ensure API works to pass in *args and **kwargs easily; Do later

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -217,7 +217,7 @@ class Options:
 
     re-writing implementations to be backend agnostic (through "wrapper" layer ), the
     option class won't need to be named after a backend; maybe just take __solver__
-    attribute to map the solver funciton [it could actually be the callable?
+    attribute to map the solver function [it could actually be the callable?
     scipy.minimize, lol sorry Kenny, you can change it after release once I'm bored]
     implementations dictionary needs to key on solver and be the arg/kwarg location for
     the numeric callbacks (for this model/paramters) and a few other things like initial

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -881,7 +881,7 @@ class ModelTemplateType(BaseModelType):
         if model_metaclass is not None:
             new_cls.user_model_metaclass = model_metaclass
             model_metaclass.baseclass_for_inheritance = new_cls
-            log.debug("prcessing for model metaclass asssigned, new")
+            log.debug("processing for model metaclass asssigned, new")
 
         if as_template:
             impl = getattr(implementations, new_cls.__mro__[1].__name__, None)

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -1536,7 +1536,7 @@ submodels from atmosphere etc models from Condor-Flight?
 placeholders: elements defined by library creators to allow user inputs; condor provides
 substitution mechanisms, etc. ~ expected uer input
 
-submodels are mdoels that don't make sense w/o their parent, maybe add configuration (like
+submodels are models that don't make sense w/o their parent, maybe add configuration (like
 singleton). inner_to arg becomes modifying? because submodels only exist to modify their
 parent?  maybe submodel modifies its superior? 
 

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -803,7 +803,7 @@ class ModelTemplateType(BaseModelType):
         cls, model_name, bases, as_template=False, model_metaclass=None, **kwargs
     ):
         if model_metaclass is not None:
-            log.debug("processing for model metaclass asssigned, prepare")
+            log.debug("processing for model metaclass assigned, prepare")
         if cls.is_user_model(bases) and not as_template:
             log.debug(
                 "dispatch __prepare__ for user model %s, %s",

--- a/src/condor/solvers/casadi_warmstart_wrapper.py
+++ b/src/condor/solvers/casadi_warmstart_wrapper.py
@@ -31,7 +31,7 @@ class CasadiWarmstartWrapperBase:
     autodiff on it. And we will just become a casadi.Callback, rather than using the
     shim to construct an operator.
 
-    addiitonal notes:
+    additional notes:
 
     I like having all the direct casadi stuff outside of implementaitons.iterative,
     so not having casadi-speicifc constructions, but maybe it's OK for this case since

--- a/src/condor/solvers/casadi_warmstart_wrapper.py
+++ b/src/condor/solvers/casadi_warmstart_wrapper.py
@@ -33,7 +33,7 @@ class CasadiWarmstartWrapperBase:
 
     additional notes:
 
-    I like having all the direct casadi stuff outside of implementaitons.iterative,
+    I like having all the direct casadi stuff outside of implementations.iterative,
     so not having casadi-speicifc constructions, but maybe it's OK for this case since
     the solver is casadi itself?
     basically because of the API requirements of casadi, either condor needs to better

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -942,7 +942,7 @@ class AdjointSystem(System):
             yield result.state_result.t[event.index]
             # nothing about segment_idx will get used the first time (terminal event)
             # and would be out-of-bounds if if tried -- simulate will use the yielded
-            # time to determine inital condition, then calls next to set endpoint of
+            # time to determine initial condition, then calls next to set endpoint of
             # next segment then propoagate it.
 
             # so on first iteration, will not propoagate, will hit first iteration of

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -945,7 +945,7 @@ class AdjointSystem(System):
             # time to determine initial condition, then calls next to set endpoint of
             # next segment then propagate it.
 
-            # so on first iteration, will not propoagate, will hit first iteration of
+            # so on first iteration, will not propagate, will hit first iteration of
             # simulate's loop and call next-yield. so do terminal update (can optimize
             # code to reduce computations if needed) then loop.
             # self.update(event)

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -439,7 +439,7 @@ class NextTimeFromSlice:
         return t < self.start
 
     def after_stop(self, t):
-        # if t is exactly stop time, this has already occured
+        # if t is exactly stop time, this has already occurred
         if self.direction < 0:
             return t <= self.stop
         return t >= self.stop

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -953,7 +953,7 @@ class AdjointSystem(System):
             # so update for terminal event is right, but could optimize performance for
             # special cases/maybe need distinct expression for update (to implement
             # update from from true terminal condition to effect of an immediate update)
-            # then when this yields initial event (i.e., index=1) will THEN propoagate
+            # then when this yields initial event (i.e., index=1) will THEN propagate
             # backwards to initial condition.
 
         # then exits above loop, will have just simulated to t0 and handled any possible

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -943,7 +943,7 @@ class AdjointSystem(System):
             # nothing about segment_idx will get used the first time (terminal event)
             # and would be out-of-bounds if if tried -- simulate will use the yielded
             # time to determine initial condition, then calls next to set endpoint of
-            # next segment then propoagate it.
+            # next segment then propagate it.
 
             # so on first iteration, will not propoagate, will hit first iteration of
             # simulate's loop and call next-yield. so do terminal update (can optimize

--- a/tests/test_trajectory_analysis.py
+++ b/tests/test_trajectory_analysis.py
@@ -40,7 +40,7 @@ def test_ct_lqr():
 
     lqr_are = DblIntLQR(K)
 
-    # causes an AttributeError, I guess becuase the Jacobian hasn't been requested?
+    # causes an AttributeError, I guess because the Jacobian hasn't been requested?
     # jac_callback = lqr_are.implementation.callback.jac_callback
     # jac_callback(K, [0])
 


### PR DESCRIPTION
Corrected several spelling issues in various files.

### List of modifications:
- `design/prototype_condor_sgm.py`, line 29: `neeed` → `need`
- `design/prototype_condor_sgm.py`, line 253: `expressino` → `expression`
- `design/prototype_condor_sgm.py`, line 265: `expressin` → `expressing`
- `docs/howto_src/table_basics.py`, line 10: `provids` → `provides`
- `docs/tutorial_src/polar_transform.py`, line 30: `evaulate` → `evaluate`
- `examples/LinCovCW.py`, line 86: `generla` → `general`
- `examples/orbital_1.py`, line 215: `paremter` → `parameter`
- `examples/orbital_3.py`, line 83: `generla` → `general`
- `examples/upcycle/high_bypass_turbofan.py`, line 28: `relavant` → `relevant`
- `examples/upcycle/high_bypass_turbofan.py`, line 30: `relavent` → `relevant`
- `examples/upcycle/high_bypass_turbofan.py`, line 97: `conneting` → `connecting`
- `examples/upcycle/high_bypass_turbofan.py`, line 104: `implictly` → `implicitly`
- `examples/upcycle/high_bypass_turbofan.py`, line 306: `instace` → `instance`
- `src/condor/__init__.py`, line 20: `tempalte` → `template`
- `src/condor/__init__.py`, line 51: `modificaiton` → `modification`
- `src/condor/__init__.py`, line 69: `accesible` → `accessible`
- `src/condor/__init__.py`, line 75: `attriburtes` → `attributes`
- `src/condor/__init__.py`, line 111: `embeded` → `embedded`
- `src/condor/__init__.py`, line 112: `substitue` → `substitute`
- `src/condor/__init__.py`, line 162: `implementaiton` → `implementation`
- `src/condor/backends/default.py`, line 88: `libary` → `library`
- `src/condor/backends/element_mixin.py`, line 91: `libary` → `library`
- `src/condor/backends/scipy/__init__.py`, line 250: `admitedly` → `admittedly`
- `src/condor/contrib.py`, line 132: `initialier` → `initializer`
- `src/condor/contrib.py`, line 228: `initialier` → `initializer`
- `src/condor/contrib.py`, line 290: `indepdendent` → `independent`
- `src/condor/contrib.py`, line 295: `auxilary` → `auxiliary`
- `src/condor/contrib.py`, line 320: `subsitution` → `substitution`
- `src/condor/contrib.py`, line 344: `indepdent` → `independent`
- `src/condor/contrib.py`, line 391: `arrray` → `array`
- `src/condor/contrib.py`, line 397: `althogh` → `although`
- `src/condor/contrib.py`, line 415: `funciton` → `function`
- `src/condor/contrib.py`, line 431: `neccessary` → `necessary`
- `src/condor/contrib.py`, line 457: `exlcude` → `exclude`
- `src/condor/contrib.py`, line 588: `occuring` → `occurring`
- `src/condor/contrib.py`, line 590: `intitial` → `initial`
- `src/condor/contrib.py`, line 646: `exlcude` → `exclude`
- `src/condor/contrib.py`, line 713: `occurance` → `occurrence`
- `src/condor/contrib.py`, line 875: `actully` → `actually`
- `src/condor/fields.py`, line 31: `subsytem` → `subsystem`
- `src/condor/fields.py`, line 59: `chek` → `check`
- `src/condor/fields.py`, line 705: `doument` → `document`
- `src/condor/fields.py`, line 705: `programatically` → `programmatically`
- `src/condor/implementations/__init__.py`, line 24: `settter` → `setter`
- `src/condor/implementations/iterative.py`, line 263: `sensitivty` → `sensitivity`
- `src/condor/implementations/sgm_trajectory.py`, line 190: `occurance` → `occurrence`
- `src/condor/models.py`, line 220: `funciton` → `function`
- `src/condor/models.py`, line 223: `paramters` → `parameters`
- `src/condor/models.py`, line 806: `prcessing` → `processing`
- `src/condor/models.py`, line 806: `asssigned` → `assigned`
- `src/condor/models.py`, line 884: `prcessing` → `processing`
- `src/condor/models.py`, line 884: `asssigned` → `assigned`
- `src/condor/models.py`, line 1117: `substitue` → `substitute`
- `src/condor/models.py`, line 1270: `recieved` → `received`
- `src/condor/models.py`, line 1451: `implementaitons` → `implementations`
- `src/condor/models.py`, line 1539: `mdoels` → `models`
- `src/condor/solvers/casadi_warmstart_wrapper.py`, line 34: `addiitonal` → `additional`
- `src/condor/solvers/casadi_warmstart_wrapper.py`, line 36: `implementaitons` → `implementations`
- `src/condor/solvers/sweeping_gradient_method.py`, line 442: `occured` → `occurred`
- `src/condor/solvers/sweeping_gradient_method.py`, line 945: `inital` → `initial`
- `src/condor/solvers/sweeping_gradient_method.py`, line 946: `propoagate` → `propagate`
- `src/condor/solvers/sweeping_gradient_method.py`, line 948: `propoagate` → `propagate`
- `src/condor/solvers/sweeping_gradient_method.py`, line 956: `propoagate` → `propagate`
- `tests/test_trajectory_analysis.py`, line 43: `becuase` → `because`

This PR does not modify any logic or behavior.