### PR TITLE
Add floor and ceil with testing

### DIFF
--- a/src/condor/backend/operators.py
+++ b/src/condor/backend/operators.py
@@ -77,6 +77,9 @@ log = wrap(backend_mod.operators.log)
 log10 = wrap(backend_mod.operators.log10)
 sqrt = wrap(backend_mod.operators.sqrt)
 
+floor = wrap(backend_mod.operators.floor)
+ceil = wrap(backend_mod.operators.ceil)
+
 vector_norm = wrap(backend_mod.operators.vector_norm)
 trace = wrap(backend_mod.operators.trace)
 cross = wrap(backend_mod.operators.cross)

--- a/src/condor/backends/casadi/operators.py
+++ b/src/condor/backends/casadi/operators.py
@@ -32,6 +32,9 @@ log = casadi.log
 log10 = casadi.log10
 sqrt = casadi.sqrt
 
+floor = casadi.floor
+ceil = casadi.ceil
+
 eye = casadi.MX.eye
 ones = casadi.MX.ones
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -83,6 +83,20 @@ def test_fabs_sign():
     assert tfs.signx == 0
 
 
+def test_floor_ceil():
+    class TestFloorCeil(co.ExplicitSystem):
+        x = input()
+        output.floorx = ops.floor(x)
+        output.ceilx = ops.ceil(x)
+
+    tfc = TestFloorCeil(3.1)
+    assert tfc.floorx == 3
+    assert tfc.ceilx == 4
+    tfc = TestFloorCeil(4.9)
+    assert tfc.floorx == 4
+    assert tfc.ceilx == 5
+
+
 def test_if_():
     class Check(co.ExplicitSystem):
         catd = input()


### PR DESCRIPTION
Added floor and ceil operators as well as operator testing. Floor and ceil naming and function are compliant with python array API standard. Replaces #31.