### PR TITLE
Handle missing implementation when resampling

### DIFF
--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -670,7 +670,10 @@ class TrajectoryAnalysis(
             return self
 
         new_self = model.__new__(model)
-        new_self.implementation = self.implementation
+        if getattr(self, "implementation", False):
+            new_self.implementation = self.implementation
+        else:
+            include_output = False # override include_output if implementation is not found
         new_self._original_instance = original_instance
         new_self.bind_field(self.parameter)
         new_self.input_kwargs = self.input_kwargs

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -670,10 +670,11 @@ class TrajectoryAnalysis(
             return self
 
         new_self = model.__new__(model)
+        # TODO: add option to rebuild the implemention
         if getattr(self, "implementation", False):
             new_self.implementation = self.implementation
-        else:
-            include_output = False # override include_output if implementation is not found
+        else:  # override include_output if implementation is not found
+            include_output = False
         new_self._original_instance = original_instance
         new_self.bind_field(self.parameter)
         new_self.input_kwargs = self.input_kwargs

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -670,6 +670,7 @@ class TrajectoryAnalysis(
             return self
 
         new_self = model.__new__(model)
+        # TODO: add option to rebuild the implemention
         if getattr(self, "implementation", False):
             new_self.implementation = self.implementation
         else:


### PR DESCRIPTION
When running `TrajectoryAnalysis` in parallel/pickled function, implementation is missing. Resampling with `include_output=True` requires the implementation. Changes to `resample()` to only assign the implementation to the resampled sim only if it exists, and overrides `include_output` to `False` if the implementation is missing. Added a `TODO:` to optionally reconstruct the implementation. 