### PR TITLE
ExplicitSystem Substitution

### DIFF
--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -447,7 +447,10 @@ def evalf(expr, backend_repr2value):
         list(backend_repr2value.keys()),
         expr,
     )
-    return func(*backend_repr2value.values())
+    out = func(*backend_repr2value.values())
+    if isinstance(out, dict):
+        return out["o0"].toarray()
+    return out
 
 
 class CasadiFunctionCallback(casadi.Callback):

--- a/src/condor/implementations/simple.py
+++ b/src/condor/implementations/simple.py
@@ -1,11 +1,12 @@
 import numpy as np
-import condor as co
 
 from condor.backend import (
     callables_to_operator,
-    expression_to_operator,
-    get_symbol_data,
     evalf,
+    get_symbol_data,
+)
+from condor.backend import (
+    operators as ops,
 )
 from condor.fields import BaseElement, Field, MatchedElement, MatchedField, asdict
 
@@ -43,11 +44,19 @@ class ExplicitSystem:
 
     def __call__(self, model_instance):
         if isinstance(model_instance.input.flatten(), np.ndarray):
-            self.out = evalf(self.symbol_outputs, {self.symbol_inputs:model_instance.input.flatten()})
+            self.out = evalf(
+                self.symbol_outputs,
+                {self.symbol_inputs: model_instance.input.flatten()},
+            )
         else:
-            inputDict = {getattr(self.model, k).backend_repr:v for k,v in model_instance.input.asdict().items()}
-            self.out = co.backend.operators.substitute(self.symbol_outputs, inputDict)
+            new_input = model_instance.input.wrap(model_instance.input.flatten())
+            input_dict = {
+                getattr(self.model, k).backend_repr: v
+                for k, v in new_input.asdict().items()
+            }
+            self.out = ops.substitute(self.symbol_outputs, input_dict)
         model_instance.bind_field(self.model.output.wrap(self.out))
+
 
 symmetric_error_message = (
     "symmetric flag only applies for two matched fields that are the same"

--- a/src/condor/implementations/simple.py
+++ b/src/condor/implementations/simple.py
@@ -1,9 +1,11 @@
 import numpy as np
+import condor as co
 
 from condor.backend import (
     callables_to_operator,
     expression_to_operator,
     get_symbol_data,
+    evalf,
 )
 from condor.fields import BaseElement, Field, MatchedElement, MatchedField, asdict
 
@@ -37,19 +39,15 @@ class ExplicitSystem:
     def construct(self, model):
         self.symbol_inputs = model.input.flatten()
         self.symbol_outputs = model.output.flatten()
-
         self.model = model
-        self.func = expression_to_operator(
-            [self.symbol_inputs],
-            self.symbol_outputs,
-            name=model.__name__,
-        )
 
     def __call__(self, model_instance):
-        self.args = model_instance.input.flatten()
-        self.out = self.func(self.args)
+        if isinstance(model_instance.input.flatten(), np.ndarray):
+            self.out = evalf(self.symbol_outputs, {self.symbol_inputs:model_instance.input.flatten()})
+        else:
+            inputDict = {getattr(self.model, k).backend_repr:v for k,v in model_instance.input.asdict().items()}
+            self.out = co.backend.operators.substitute(self.symbol_outputs, inputDict)
         model_instance.bind_field(self.model.output.wrap(self.out))
-
 
 symmetric_error_message = (
     "symmetric flag only applies for two matched fields that are the same"

--- a/src/condor/implementations/simple.py
+++ b/src/condor/implementations/simple.py
@@ -43,17 +43,20 @@ class ExplicitSystem:
         self.model = model
 
     def __call__(self, model_instance):
-        if isinstance(model_instance.input.flatten(), np.ndarray):
+        new_input = model_instance.input.wrap(model_instance.input.flatten())
+        input_dict = {
+            getattr(self.model, k).backend_repr: v
+            for k, v in new_input.asdict().items()
+        }
+        if (
+            isinstance(model_instance.input.flatten(), np.ndarray)
+            and self.symbol_inputs.size != 0
+        ):
             self.out = evalf(
                 self.symbol_outputs,
                 {self.symbol_inputs: model_instance.input.flatten()},
             )
         else:
-            new_input = model_instance.input.wrap(model_instance.input.flatten())
-            input_dict = {
-                getattr(self.model, k).backend_repr: v
-                for k, v in new_input.asdict().items()
-            }
             self.out = ops.substitute(self.symbol_outputs, input_dict)
         model_instance.bind_field(self.model.output.wrap(self.out))
 

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -47,6 +47,7 @@ class BaseModelMetaData:
     options: object = None
 
     inherited_methods: dict = dc.field(default_factory=dict)
+    is_template: bool = False
 
     # assembly/component can also get children/parent
     # assembly/components get inheritance rules? yes, submodels don't need it -- only
@@ -891,7 +892,9 @@ class ModelTemplateType(BaseModelType):
                 )
                 is not None
             ):
-                meta = user_model_metclass.metadata_class(model_name=model_name)
+                meta = user_model_metclass.metadata_class(
+                    model_name=model_name, is_template=as_template
+                )
             # actually creating a model template, TODO at some point tap into
             # inheritance tree for now nothing fails this check
             if as_template:
@@ -1463,6 +1466,8 @@ class Model(metaclass=ModelType):
                 }
             )
 
+        self.update_model_assignments(model_assignments)
+
         for (
             embedded_model_ref_name,
             embedded_model_instance,
@@ -1489,6 +1494,9 @@ class Model(metaclass=ModelType):
             )
 
             bound_embedded_model.bind_embedded_models()
+
+    def update_model_assignments(self, model_assignments):
+        return
 
     def bind_input_as_embedded(
         self,
@@ -1537,6 +1545,7 @@ class Model(metaclass=ModelType):
             if isinstance(sym_bound_field, FieldValues) and isinstance(
                 ran_bound_field, FieldValues
             ):
+                # TODO: sym_bound_field_dict is really just list_of?
                 sym_bound_field_dict = dc.asdict(sym_bound_field)
                 ran_bound_field_dict = dc.asdict(ran_bound_field)
                 assignment_updates.update(


### PR DESCRIPTION
Removed expression_to_operator in ExplicitSystem. Replaced with evalf and substitution of expressions instead. Also includes #80 