### PR TITLE
Avoid constructing a Result with a DM for now

### DIFF
--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -660,7 +660,7 @@ class System:
             yield np.array(t).reshape(-1)[0]
 
     def __call__(self, p):
-        self.result = Result(p=p, system=self)
+        self.result = Result(p=np.array(p), system=self)
         self.system_solver.simulate()
         result = self.result
         result.t = np.array(result.t)


### PR DESCRIPTION
Fixes a recursion issue with casadi 3.8.0 array dispatch when calling save. I think this could be considered a bug in casadi, hence the "for now."

There's probably more we should check (e.g. #91) but this should looks like enough to maintain compatibility.