### PR TITLE
Casadi array

### DIFF
--- a/docs/examples_src/ct_lqr.py
+++ b/docs/examples_src/ct_lqr.py
@@ -11,8 +11,8 @@ import condor as co
 
 
 class DblInt(co.ODESystem):
-    A = np.array([[0.0, 1.0], [0.0, 0.0]])
-    B = np.array([[0.0], [1.0]])
+    A = co.backend.operators.array([[0.0, 1.0], [0.0, 0.0]])
+    B = co.backend.operators.array([[0.0], [1.0]])
 
     K = parameter(shape=(1, B.shape[0]))
 

--- a/docs/examples_src/orbital_1.py
+++ b/docs/examples_src/orbital_1.py
@@ -109,7 +109,7 @@ class MajorBurn(LinCovCW.Event):
     T_pv = stm[:3, 3:]
     T_pv_inv = ca.solve(T_pv, ops.eye(3))
 
-    Delta_v = (T_pv_inv @ rd - T_pv_inv @ T_pp @ x[:3, 0]) - x[3:, 0]
+    Delta_v = (T_pv_inv @ rd - T_pv_inv @ T_pp @ x[:3, [0]]) - x[3:, [0]]
 
     update[Delta_v_mag] = Delta_v_mag + ca.norm_2(Delta_v)
     update[x] = x + ops.concat([ops.zeros((3, 1)), Delta_v])

--- a/docs/examples_src/sp_lqr.py
+++ b/docs/examples_src/sp_lqr.py
@@ -11,8 +11,8 @@ import condor as co
 
 
 class DblIntSampled(co.ODESystem):
-    A = np.array([[0.0, 1.0], [0.0, 0.0]])
-    B = np.array([[0.0], [1.0]])
+    A = co.backend.operators.array([[0.0, 1.0], [0.0, 0.0]])
+    B = co.backend.operators.array([[0.0], [1.0]])
 
     K = parameter(shape=(1, B.shape[0]))
     dt = parameter()

--- a/docs/examples_src/state_switched.py
+++ b/docs/examples_src/state_switched.py
@@ -13,8 +13,8 @@ import condor as co
 
 
 class DblInt(co.ODESystem):
-    A = np.array([[0, 1], [0, 0]])
-    B = np.array([[0], [1]])
+    A = co.backend.operators.array([[0, 1], [0, 0]])
+    B = co.backend.operators.array([[0], [1]])
 
     x = state(shape=A.shape[0])
     mode = state()
@@ -55,8 +55,7 @@ from scipy.optimize import bisect
 
 class Transfer(DblInt.TrajectoryAnalysis):
     initial[x] = [-9.0, 0.0]
-    xd = [1.0, 2.0]
-    Q = np.eye(2)
+    xd = co.backend.operators.array([1.0, 2.0]).reshape((2, 1))
     cost = trajectory_output(((x - xd).T @ (x - xd)) / 2)
     tf = 20.0
 

--- a/docs/examples_src/time_switch.py
+++ b/docs/examples_src/time_switch.py
@@ -21,8 +21,8 @@ with_time_state = False
 
 
 class DblInt(co.ODESystem):
-    A = np.array([[0, 1], [0, 0]])
-    B = np.array([[0], [1]])
+    A = co.backend.operators.array([[0, 1], [0, 0]])
+    B = co.backend.operators.array([[0], [1]])
 
     x = state(shape=A.shape[0])
     mode = state()

--- a/docs/howto_src/configuration.py
+++ b/docs/howto_src/configuration.py
@@ -27,12 +27,13 @@ on what the user passes in for the state and input matrices.
 # To use this module, we use :func:`~condor.settings.get_module`, passing its declared
 # settings as concrete keyword arguments.
 
-import numpy as np
-
 import condor
 
-A = np.array([[0.0, 1.0], [0.0, 0.0]])
-B = np.array([[0.0], [1.0]])
+backend = condor.backend
+ops = backend.operators
+
+A = ops.array([[0.0, 1.0], [0.0, 0.0]])
+B = ops.array([[0.0], [1.0]])
 
 dblint_mod = condor.settings.get_module("_lti", A=A, B=B)
 
@@ -61,7 +62,7 @@ plt.plot(sim.t, sim.x[0].squeeze())
 # %%
 # We can also re-use the module with a different configuration:
 
-LTI_exp = condor.settings.get_module("_lti", A=np.array([[0, 1], [-2, -3]])).LTI
+LTI_exp = condor.settings.get_module("_lti", A=ops.array([[0, 1], [-2, -3]])).LTI
 
 
 class Sim(LTI_exp.TrajectoryAnalysis):
@@ -149,7 +150,7 @@ plt.plot(sim.t, sim.x[0].squeeze())
 
 # %%
 
-LTI_exp = make_LTI(A=np.array([[0, 1], [-2, -3]]))
+LTI_exp = make_LTI(A=ops.array([[0, 1], [-2, -3]]))
 
 
 class Sim(LTI_exp.TrajectoryAnalysis):

--- a/src/condor/backend/__init__.py
+++ b/src/condor/backend/__init__.py
@@ -14,6 +14,7 @@ symbol_generator = backend_mod.symbol_generator
 symbol_like = backend_mod.symbol_like
 get_symbol_data = backend_mod.get_symbol_data
 symbol_is = backend_mod.symbol_is
+is_symbol = backend_mod.is_symbol
 BackendSymbolData = backend_mod.BackendSymbolData
 
 

--- a/src/condor/backend/operators.py
+++ b/src/condor/backend/operators.py
@@ -36,6 +36,8 @@ substitute = backend_mod.operators.substitute
 zeros = backend_mod.operators.zeros
 eye = backend_mod.operators.eye
 ones = backend_mod.operators.ones
+array = backend_mod.operators.array
+#: create an array from numeric (or symbolic?) elements
 
 
 # "element-wise functions"

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -18,70 +18,6 @@ for attr in casadi.__dir__():
     if attr.startswith("OP_"):
         print(f"{attr}: {getattr(casadi, attr)}")
 
------
-# TODO: ArrayInterface has nice static methods that mayy be useful: (if stable?)
-_arg_has_symbolic
-_as_array
-
-------
-
-import casadi as ca
-import numpy as np
-import condor as co
-backend = co.backend
-ops = backend.operators
-
-b = np.array([[0,1,0]]).T
-u = ca.array(ca.MX.sym("u", 1,1))
-
-b =ca.array([[0,1,0]]).T
-b = np.array([[0,1,0]]).T
-u = ca.array([[1]])
-b@u
-
-
-a = ca.MX.sym("a", 12,1)
-f1 = backend.expression_to_operator([a], a.reshape((4,3)), "func")
-
-x = np.arange(12)
-
-print(np.all(f1(x) == x.reshape((4,3))))
-f1(x)
-
-f2 = backend.expression_to_operator([a], ca.array(a).reshape((4,3)), "func")
-
-print(np.all(f2(x) == x.reshape((4,3))))
-f2(x)
-
-
-f3 = backend.expression_to_operator([a], ops.sin(ca.array(a).reshape((4,3))), "func")
-print(np.all(f3(x) == np.sin(x.reshape((4,3)))))
-f3(x)
-
----
-
-a = ca.MX.sym("a", 4,3)
-f1 = backend.expression_to_operator([a], a, "func")
-
-x = np.arange(12).reshape((4,3))
-
-print(np.all(f1(x) == x))
-f1(x)
-
-f2 = backend.expression_to_operator([a], ca.array(a).reshape((-1,1)), "func")
-
-print(np.all(f2(x) == x.reshape(-1)))
-f2(x)
-
-
-f3 = backend.expression_to_operator([a], a.T.reshape((-1,1)), "func")
-print(np.all(f3(x) == x.reshape(-1)))
-f3(x)
-
-ops
-
-
-
 """
 
 
@@ -545,11 +481,6 @@ def evalf(expr, backend_repr2value):
     """evaluate :attr:`expr` with dictionary of {symbol: value}"""
     if not isinstance(expr, list):
         expr = [expr]
-    # expr = [
-    #     expr_ if isinstance(expr_, symbol_class) else expr_.to_casadi()
-    #     for expr_ in expr
-    # ]
-    # args = [v.to_casadi() for v in backend_repr2value.keys()]
     args = list(backend_repr2value.keys())
     func = casadi.Function(
         "temp_func",

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -206,7 +206,7 @@ class BackendSymbolData(BackendSymbolDataMixin):
                 return np.array(value).reshape(-1)
 
         if self.symmetric:
-            value = unique_to_symmetric(value, symbolic=is_symbolic(value))
+            value = unique_to_symmetric(value, symbolic=is_symbol(value))
 
         if (isinstance(value, symbol_class) and value.is_constant()) or (
             isinstance(value, casadi.array)

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -6,18 +6,76 @@ import casadi
 from condor.backends.casadi import operators as operators  # noqa: PLC0414
 from condor.backends.element_mixin import BackendSymbolDataMixin
 
+casadi.GlobalOptions.setNumpyMode(True)
+
 symbol_class = casadi.MX
+# symbol_class = casadi.array
+# base_symbol_class = symbol_class
 
 """
 # a useful stub for getting the op codes in casadi
 for attr in casadi.__dir__():
     if attr.startswith("OP_"):
         print(f"{attr}: {getattr(casadi, attr)}")
+
+------
+
+import casadi as ca
+import numpy as np
+import condor as co
+backend = co.backend
+ops = backend.operators
+
+
+a = ca.MX.sym("a", 12,1)
+f1 = backend.expression_to_operator([a], a.reshape((4,3)), "func")
+
+x = np.arange(12)
+
+print(np.all(f1(x) == x.reshape((4,3))))
+f1(x)
+
+f2 = backend.expression_to_operator([a], ca.array(a).reshape((4,3)), "func")
+
+print(np.all(f2(x) == x.reshape((4,3))))
+f2(x)
+
+
+f3 = backend.expression_to_operator([a], ops.sin(ca.array(a).reshape((4,3))), "func")
+print(np.all(f3(x) == np.sin(x.reshape((4,3)))))
+f3(x)
+
+---
+
+a = ca.MX.sym("a", 4,3)
+f1 = backend.expression_to_operator([a], a, "func")
+
+x = np.arange(12).reshape((4,3))
+
+print(np.all(f1(x) == x))
+f1(x)
+
+f2 = backend.expression_to_operator([a], ca.array(a).reshape((-1,1)), "func")
+
+print(np.all(f2(x) == x.reshape(-1)))
+f2(x)
+
+
+f3 = backend.expression_to_operator([a], a.T.reshape((-1,1)), "func")
+print(np.all(f3(x) == x.reshape(-1)))
+f3(x)
+
+ops
+
+
+
 """
 
 
 def symbols_in(expression):
     """return the leaf symbols in the :attr:`expression`"""
+    if isinstance(expression, casadi.array):
+        expression = expression.to_casadi()
     if not isinstance(expression, symbol_class):
         return []
     else:
@@ -44,9 +102,9 @@ def process_relational_element(elem):
     # check if the backend_repr is a comparison op
     # check if the bounds are constant
     relational_op = False
-    if elem.backend_repr.is_binary():
-        lhs = elem.backend_repr.dep(0)
-        rhs = elem.backend_repr.dep(1)
+    if elem.backend_repr.to_casadi().is_binary():
+        lhs = elem.backend_repr.to_casadi().dep(0)
+        rhs = elem.backend_repr.to_casadi().dep(1)
 
     if hasattr(elem, "lower_bound") and (
         not isinstance(elem.lower_bound, np.ndarray)
@@ -64,7 +122,7 @@ def process_relational_element(elem):
     else:
         real_upper_bound = False
 
-    if elem.backend_repr.op() in (casadi.OP_LT, casadi.OP_LE):
+    if elem.backend_repr.to_casadi().op() in (casadi.OP_LT, casadi.OP_LE):
         relational_op = True
         mhs = casadi.MX()
 
@@ -76,8 +134,8 @@ def process_relational_element(elem):
             msg = "Setting inequality and equality relation doesn't make sense"
             raise ValueError(msg)
         if lhs.op() in (casadi.OP_LT, casadi.OP_LE):
-            mhs = lhs.dep(1)
-            lhs = lhs.dep(0)
+            mhs = casadi.array(lhs.dep(1))
+            lhs = casadi.array(lhs.dep(0))
             if rhs.backend_repr.op() in (casadi.OP_LT, casadi.OP_LE):
                 msg = "Too many inequalities deep"
                 raise ValueError(msg)
@@ -123,17 +181,17 @@ def process_relational_element(elem):
             else:
                 raise ValueError
 
-        elem.lower_bound = lhs
-        elem.backend_repr = mhs
-        elem.upper_bound = rhs
+        elem.lower_bound = casadi.array(lhs)
+        elem.backend_repr = casadi.array(mhs)
+        elem.upper_bound = casadi.array(rhs)
 
     # elif elem.backend_repr.op() in (casadi.OP_GT, casadi.OP_GE):
     #    relational_op = True
     #    elem.backend_repr = rhs - lhs
     #    elem.upper_bound = 0.0
-    elif elem.backend_repr.op() == casadi.OP_EQ:
+    elif elem.backend_repr.to_casadi().op() == casadi.OP_EQ:
         relational_op = True
-        elem.backend_repr = rhs - lhs
+        elem.backend_repr = casadi.array(rhs - lhs)
         if hasattr(elem, "upper_bound"):
             elem.upper_bound = np.zeros(elem.backend_repr.shape)
         if hasattr(elem, "lower_bound"):
@@ -165,10 +223,8 @@ class BackendSymbolData(BackendSymbolDataMixin):
     def flatten_value(self, value, force_asymetric=False):
         """flatten a value to the appropriate representation for the backend"""
         if self.symmetric and not force_asymetric:
-            unique_values = symmetric_to_unique(
-                value, symbolic=isinstance(value, symbol_class)
-            )
-            if isinstance(value, symbol_class):
+            unique_values = symmetric_to_unique(value, symbolic=is_symbol(value))
+            if is_symbol(value):
                 syms = casadi.symvar(value)
                 if len(syms) == 1 and symbol_is(unique_to_symmetric(syms[0]), value):
                     return syms[0]
@@ -176,40 +232,54 @@ class BackendSymbolData(BackendSymbolDataMixin):
         if self.size == 1 and isinstance(value, (float, int)):
             return value
         else:
-            if not isinstance(value, (np.ndarray, symbol_class)):
+            if not isinstance(value, np.ndarray) and not is_symbol(value):
                 value = np.array(value)
             if isinstance(value, symbol_class):
-                value = value.T
+                value = casadi.array(value)
+            # if is_symbol(value):
+            #    value = value#.T
             return value.reshape((-1, 1))
 
     def wrap_value(self, value):
         """wrap a flattened value to the appropriate shape"""
         if self.size == 1:
-            if isinstance(value, (float, int, symbol_class)):
+            if isinstance(value, (float, int)) or is_symbol(value):
                 return value
             elif hasattr(value, "__iter__"):
                 ret_val = np.array(value).reshape(-1)[0]
-                if isinstance(ret_val, symbol_class):
+                if is_symbol(ret_val):
                     return ret_val
                 return np.array(value).reshape(-1)
 
         if self.symmetric:
-            value = unique_to_symmetric(value, symbolic=isinstance(value, symbol_class))
+            value = unique_to_symmetric(value, symbolic=is_symbolic(value))
 
-        if isinstance(value, symbol_class) and value.is_constant():
+        if is_symbol(value) and value.is_constant():
             value = value.to_DM()
 
-        if isinstance(value, casadi.DM):
-            value = value.T.toarray().reshape(self.shape)
+        if isinstance(value, symbol_class):
+            value = casadi.array(value)
 
-        if not isinstance(value, (np.ndarray, symbol_class)):
+        if isinstance(value, casadi.DM):
+            # value = value.toarray()
+            # value = value.T
+            # value = value.reshape(self.shape)
+            # value = value.toarray().reshape(self.shape[::-1]).T
+            # value = casadi.array(value)
+            value = casadi.array(value).reshape(self.shape)
+
+        if not isinstance(value, np.ndarray) and not is_symbol(value):
             value = np.array(value)
 
+        if isinstance(value, symbol_class):
+            breakpoint()
+
         if (
-            isinstance(value, symbol_class)
+            is_symbol(value)
             and not self.symmetric
             and self.shape[0] > 1
             and self.shape[1] > 1
+            and 0
         ):
             value = value.reshape(self.shape[::-1]).T
         else:
@@ -219,7 +289,6 @@ class BackendSymbolData(BackendSymbolDataMixin):
                 value = value.reshape(self.shape + (-1,))
 
         return value
-        return symbol_class(value).reshape(self.shape)
 
 
 def symmetric_to_unique(value, symbolic=True):
@@ -227,7 +296,11 @@ def symmetric_to_unique(value, symbolic=True):
     n = value.shape[0]
     unique_shape = (int(n * (n + 1) / 2), 1)
     indices = np.tril_indices(n)
-    unique_values = symbol_class(*unique_shape) if symbolic else np.empty(unique_shape)
+    unique_values = (
+        casadi.array(symbol_class(*unique_shape))
+        if symbolic
+        else np.empty(unique_shape)
+    )
     for kk, (i, j) in enumerate(zip(*indices)):
         unique_values[kk] = value[i, j]
     return unique_values
@@ -280,12 +353,12 @@ def symbol_generator(name, shape=(1, 1), symmetric=False, diagonal=False):
             msg = f"Symmetric specified but shape non-square {(n, m)}"
             raise ValueError(msg)
         unique_shape = (int(n * (n + 1) / 2), 1)
-        unique_symbols = symbol_class.sym(name, unique_shape)
+        unique_symbols = casadi.array(symbol_class.sym(name, unique_shape))
         matrix_symbols = unique_to_symmetric(unique_symbols)
         return matrix_symbols
     else:
-        raw_sym = symbol_class.sym(name, (m, n))
-        sym = raw_sym.T
+        raw_sym = casadi.array(symbol_class.sym(name, (n, m)))
+        sym = raw_sym  # .T
         return sym
 
 
@@ -305,7 +378,7 @@ def get_symbol_data(symbol, symmetric=None):
     if hasattr(symbol, "backend_repr"):
         symbol = symbol.backend_repr
 
-    if not isinstance(symbol, (symbol_class, casadi.DM)):
+    if not isinstance(symbol, (symbol_class, casadi.array, casadi.DM)):
         symbol = np.atleast_1d(symbol)
         # I'm not sure why, but before I reshaped this to a vector always. Only
         # reshaping tensors now...
@@ -322,7 +395,7 @@ def get_symbol_data(symbol, symmetric=None):
     diagonal = False
     if symmetric is None:
         # if unprovided, try to determine if symmetric
-        if isinstance(symbol, (symbol_class,)):
+        if is_symbol(symbol):
             symmetric = symbol_is(symbol, symbol.T) and size > 1
         else:
             symmetric = (
@@ -338,6 +411,10 @@ def get_symbol_data(symbol, symmetric=None):
     )
 
 
+def is_symbol(a):
+    return isinstance(a, (symbol_class, casadi.array))
+
+
 def symbol_is(a, b):
     """evaluate whether two symbols are the same with idiosyncrasies for symbol class"""
     if a.shape != b.shape:
@@ -345,6 +422,8 @@ def symbol_is(a, b):
     equality_expr = a == b
     if isinstance(equality_expr, bool):
         return equality_expr
+    if isinstance(equality_expr, casadi.array):
+        equality_expr = equality_expr.to_casadi()
     if isinstance(equality_expr, (symbol_class, casadi.DM)):
         return equality_expr.is_one() or casadi.is_equal(a, b, int(1e10))
     if isinstance(equality_expr, np.ndarray):
@@ -356,6 +435,8 @@ class WrappedSymbol:
         # assert not isinstance(arg, WrappedSymbol)
         if isinstance(symbol, WrappedSymbol):
             symbol = arg.symbol
+        if isinstance(symbol, casadi.array):
+            symbol = symbol.to_casadi()
         self.symbol = symbol
 
     def __hash__(self):
@@ -385,6 +466,8 @@ class SymbolCompatibleDict(dict):
             self[k] = v
 
     def get(self, k, default):
+        if isinstance(k, casadi.array):
+            k = k.to_casadi()
         out = super().get(k, None)
         if out is None and isinstance(k, symbol_class):
             out = super().get(k.T, None)
@@ -407,6 +490,8 @@ class SymbolCompatibleDict(dict):
                 raise KeyError from e
 
     def __setitem__(self, k, v):
+        if isinstance(k, casadi.array):
+            k = k.to_casadi()
         if isinstance(k, symbol_class) and k.op() in (
             casadi.OP_RESHAPE,
             casadi.OP_TRANSPOSE,
@@ -442,9 +527,15 @@ def evalf(expr, backend_repr2value):
     """evaluate :attr:`expr` with dictionary of {symbol: value}"""
     if not isinstance(expr, list):
         expr = [expr]
+    # expr = [
+    #     expr_ if isinstance(expr_, symbol_class) else expr_.to_casadi()
+    #     for expr_ in expr
+    # ]
+    # args = [v.to_casadi() for v in backend_repr2value.keys()]
+    args = list(backend_repr2value.keys())
     func = casadi.Function(
         "temp_func",
-        list(backend_repr2value.keys()),
+        args,
         expr,
     )
     return func(*backend_repr2value.values())
@@ -684,9 +775,15 @@ def expression_to_operator(input_symbols, output_expressions, name="", **kwargs)
     output_expressions = getattr(output_expressions, "backend_repr", output_expressions)
     if not name:
         name = "function_from_expression"
+
+    # def wrapped_function(*args):
+    #    if len(input_symbols) != len(args):
+    #        raise ValueError
+    #    for input_symbol, arg in
+
     return casadi.Function(
         name,
         input_symbols,
-        [output_expressions],
+        [casadi.array(output_expressions)],
         kwargs,
     )

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -18,6 +18,11 @@ for attr in casadi.__dir__():
     if attr.startswith("OP_"):
         print(f"{attr}: {getattr(casadi, attr)}")
 
+-----
+# TODO: ArrayInterface has nice static methods that mayy be useful: (if stable?)
+_arg_has_symbolic
+_as_array
+
 ------
 
 import casadi as ca
@@ -25,6 +30,14 @@ import numpy as np
 import condor as co
 backend = co.backend
 ops = backend.operators
+
+b = np.array([[0,1,0]]).T
+u = ca.array(ca.MX.sym("u", 1,1))
+
+b =ca.array([[0,1,0]]).T
+b = np.array([[0,1,0]]).T
+u = ca.array([[1]])
+b@u
 
 
 a = ca.MX.sym("a", 12,1)
@@ -232,7 +245,7 @@ class BackendSymbolData(BackendSymbolDataMixin):
                     return syms[0]
             return unique_values
         if self.size == 1 and isinstance(value, (float, int)):
-            return value
+            return np.array([[value]])
         else:
             if not isinstance(value, np.ndarray) and not is_symbol(value):
                 value = np.array(value)
@@ -257,7 +270,10 @@ class BackendSymbolData(BackendSymbolDataMixin):
         if self.symmetric:
             value = unique_to_symmetric(value, symbolic=is_symbolic(value))
 
-        if is_symbol(value) and value.is_constant():
+        if (isinstance(value, symbol_class) and value.is_constant()) or (
+            isinstance(value, casadi.array)
+            and not casadi.array._arg_has_symbolic(value)
+        ):
             value = value.to_DM()
 
         if isinstance(value, symbol_class):
@@ -614,6 +630,12 @@ class CasadiFunctionCallback(casadi.Callback):
         self.opts = opts
 
         self.construct()
+
+    def __call__(self, *args, **kwargs):
+        out = super().__call__(*args, **kwargs)
+        if isinstance(out, symbol_class):
+            out = casadi.array(out)
+        return out
 
     def construct(self):
         super().construct(self.placeholder_func.name(), self.opts)

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -205,6 +205,8 @@ def process_relational_element(elem):
 def shape_to_nm(shape):
     if isinstance(shape, (int, np.int64)):
         shape = (shape, 1)
+    if len(shape) == 0:
+        shape = (1, 1)
     if len(shape) > 2:
         raise ValueError
     n = shape[0]
@@ -235,9 +237,10 @@ class BackendSymbolData(BackendSymbolDataMixin):
             if not isinstance(value, np.ndarray) and not is_symbol(value):
                 value = np.array(value)
             if isinstance(value, symbol_class):
-                value = casadi.array(value)
-            # if is_symbol(value):
-            #    value = value#.T
+                # value = casadi.array(value)
+                # if is_symbol(value):
+                value = value.T
+                breakpoint()
             return value.reshape((-1, 1))
 
     def wrap_value(self, value):
@@ -282,6 +285,7 @@ class BackendSymbolData(BackendSymbolDataMixin):
             and 0
         ):
             value = value.reshape(self.shape[::-1]).T
+            breakpoint()
         else:
             try:
                 value = value.reshape(self.shape)
@@ -357,7 +361,7 @@ def symbol_generator(name, shape=(1, 1), symmetric=False, diagonal=False):
         matrix_symbols = unique_to_symmetric(unique_symbols)
         return matrix_symbols
     else:
-        raw_sym = casadi.array(symbol_class.sym(name, (n, m)))
+        raw_sym = casadi.array(symbol_class.sym(name, n * m)).reshape((n, m))
         sym = raw_sym  # .T
         return sym
 
@@ -780,6 +784,13 @@ def expression_to_operator(input_symbols, output_expressions, name="", **kwargs)
     #    if len(input_symbols) != len(args):
     #        raise ValueError
     #    for input_symbol, arg in
+
+    def process_input(sym):
+        if isinstance(sym, casadi.array):
+            sym = sym.to_casadi()
+        return sym
+
+    input_symbols = [process_input(sym) for sym in input_symbols]
 
     return casadi.Function(
         name,

--- a/src/condor/backends/casadi/__init__.py
+++ b/src/condor/backends/casadi/__init__.py
@@ -95,9 +95,16 @@ def symbols_in(expression):
         return casadi.symvar(expression)
 
 
-def is_constant(symbol):
+def is_symbol(value):
+    return (isinstance(value, symbol_class) and not value.is_constant()) or (
+        isinstance(value, casadi.array) and casadi.array._arg_has_symbolic(value)
+    )
+
+
+def is_constant(value):
     """evaluate whether the :attr:`symbol` is a constant (e.g., numeric)"""
-    return not isinstance(symbol, symbol_class) or symbol.is_constant()
+    # return not isinstance(symbol, symbol_class) or symbol.is_constant()
+    return bool(1 - is_symbol(value))
 
 
 def process_relational_element(elem):
@@ -247,13 +254,8 @@ class BackendSymbolData(BackendSymbolDataMixin):
         if self.size == 1 and isinstance(value, (float, int)):
             return np.array([[value]])
         else:
-            if not isinstance(value, np.ndarray) and not is_symbol(value):
+            if isinstance(value, (list, tuple)):
                 value = np.array(value)
-            if isinstance(value, symbol_class):
-                # value = casadi.array(value)
-                # if is_symbol(value):
-                value = value.T
-                breakpoint()
             return value.reshape((-1, 1))
 
     def wrap_value(self, value):
@@ -429,10 +431,6 @@ def get_symbol_data(symbol, symmetric=None):
         symmetric=symmetric,
         diagonal=diagonal,
     )
-
-
-def is_symbol(a):
-    return isinstance(a, (symbol_class, casadi.array))
 
 
 def symbol_is(a, b):
@@ -802,11 +800,6 @@ def expression_to_operator(input_symbols, output_expressions, name="", **kwargs)
     if not name:
         name = "function_from_expression"
 
-    # def wrapped_function(*args):
-    #    if len(input_symbols) != len(args):
-    #        raise ValueError
-    #    for input_symbol, arg in
-
     def process_input(sym):
         if isinstance(sym, casadi.array):
             sym = sym.to_casadi()
@@ -814,9 +807,18 @@ def expression_to_operator(input_symbols, output_expressions, name="", **kwargs)
 
     input_symbols = [process_input(sym) for sym in input_symbols]
 
-    return casadi.Function(
+    func = casadi.Function(
         name,
         input_symbols,
         [casadi.array(output_expressions)],
         kwargs,
     )
+
+    def wrapped_function(*args):
+        out = func(*args)
+        out = casadi.array(out)
+        if is_constant(out):
+            out = np.array(out)
+        return out
+
+    return wrapped_function

--- a/src/condor/backends/casadi/operators.py
+++ b/src/condor/backends/casadi/operators.py
@@ -35,11 +35,17 @@ sqrt = casadi.sqrt
 floor = casadi.floor
 ceil = casadi.ceil
 
-eye = casadi.MX.eye
-ones = casadi.MX.ones
 
 fabs = casadi.fabs
 sign = casadi.sign
+
+
+def eye(*args, **kwargs):
+    return casadi.array(casadi.MX.eye(*args, **kwargs))
+
+
+def ones(*args, **kwargs):
+    return casadi.array(casadi.MX.ones(*args, **kwargs))
 
 
 def diag(v, k=0):
@@ -83,6 +89,7 @@ def diff(x, axis=-1, n=1):
 
 
 def prod(x, axis=None):
+    return np.atleast_2d(np.prod(x, axis))  # .atleast2d()
     if axis is None:
         out = 1
         for i in range(x.shape[0]):
@@ -131,6 +138,13 @@ pinv = casadi.pinv
 
 
 def concat(arrs, axis=0):
+    if len(arrs) == 0:
+        return np.array(arrs)
+    if len(arrs) == 1 and np.isscalar(arrs[0]):
+        if isinstance(arrs, (casadi.MX, casadi.array)):
+            return arrs
+        return np.array(arrs)
+    return np.concat(arrs, axis=axis)
     """implement concat from array API for casadi"""
     if not arrs:
         return arrs
@@ -160,6 +174,7 @@ def zeros(shape=(1, 1)):
 def min(x, axis=None):
     if not isinstance(x, backend.symbol_class):
         x = concat(x)
+    return np.min(x, axis=axis)
     if axis is not None:
         msg = "Only axis=None supported"
         raise ValueError(msg)
@@ -169,6 +184,7 @@ def min(x, axis=None):
 def max(x, axis=None):
     if not isinstance(x, backend.symbol_class):
         x = concat(x)
+    return np.max(x, axis=axis)
     if axis is not None:
         msg = "Only axis=None supported"
         raise ValueError(msg)

--- a/src/condor/backends/casadi/operators.py
+++ b/src/condor/backends/casadi/operators.py
@@ -144,7 +144,10 @@ def concat(arrs, axis=0):
         if isinstance(arrs, (casadi.MX, casadi.array)):
             return arrs
         return np.array(arrs)
-    return np.concat(arrs, axis=axis)
+    try:
+        return np.concat(arrs, axis=axis)
+    except ValueError:
+        return np.array(arrs)
     """implement concat from array API for casadi"""
     if not arrs:
         return arrs
@@ -169,6 +172,9 @@ def unstack(arr, axis=0):
 
 def zeros(shape=(1, 1)):
     return backend.symbol_class(*shape)
+
+
+array = casadi.array
 
 
 def min(x, axis=None):

--- a/src/condor/backends/casadi/operators.py
+++ b/src/condor/backends/casadi/operators.py
@@ -90,21 +90,6 @@ def diff(x, axis=-1, n=1):
 
 def prod(x, axis=None):
     return np.atleast_2d(np.prod(x, axis))  # .atleast2d()
-    if axis is None:
-        out = 1
-        for i in range(x.shape[0]):
-            for j in range(x.shape[1]):
-                out *= x[i, j]
-    elif axis == 0:
-        out = ones((1, x.shape[1]))
-        for i in range(x.shape[0]):
-            out *= x[i, :]
-    elif axis == 1:
-        out = ones((x.shape[0], 1))
-        for j in range(x.shape[1]):
-            out *= x[:, j]
-
-    return out
 
 
 def isnan(x):
@@ -138,6 +123,7 @@ pinv = casadi.pinv
 
 
 def concat(arrs, axis=0):
+    """implement concat from array API for casadi"""
     if len(arrs) == 0:
         return np.array(arrs)
     if len(arrs) == 1 and np.isscalar(arrs[0]):
@@ -148,19 +134,6 @@ def concat(arrs, axis=0):
         return np.concat(arrs, axis=axis)
     except ValueError:
         return np.array(arrs)
-    """implement concat from array API for casadi"""
-    if not arrs:
-        return arrs
-    if np.any([isinstance(arr, backend.symbol_class) for arr in arrs]):
-        if axis == 0:
-            return casadi.vcat(arrs)
-        elif axis in (1, -1):
-            return casadi.hcat(arrs)
-        else:
-            msg = "Casadi only supports matrices"
-            raise ValueError(msg)
-    else:
-        return np.concat([np.atleast_2d(arr) for arr in arrs], axis=axis)
 
 
 def unstack(arr, axis=0):
@@ -181,20 +154,12 @@ def min(x, axis=None):
     if not isinstance(x, backend.symbol_class):
         x = concat(x)
     return np.min(x, axis=axis)
-    if axis is not None:
-        msg = "Only axis=None supported"
-        raise ValueError(msg)
-    return casadi.mmin(x)
 
 
 def max(x, axis=None):
     if not isinstance(x, backend.symbol_class):
         x = concat(x)
     return np.max(x, axis=axis)
-    if axis is not None:
-        msg = "Only axis=None supported"
-        raise ValueError(msg)
-    return casadi.mmax(x)
 
 
 unsupported_jacobian_message = (

--- a/src/condor/backends/casadi/operators.py
+++ b/src/condor/backends/casadi/operators.py
@@ -257,7 +257,7 @@ def substitute(expr, subs):
         with contextlib.suppress(RuntimeError):
             expr = casadi.evalf(expr)
 
-    return expr
+    return casadi.array(expr)
 
 
 def if_else(*conditions_actions, short_circuit=False):

--- a/src/condor/backends/element_mixin.py
+++ b/src/condor/backends/element_mixin.py
@@ -107,6 +107,7 @@ class BackendSymbolDataMixin:
             self.shape = (1, 1)
         n = self.shape[0]
         size = np.prod(self.shape)
+
         if self.symmetric:
             size = int(n * (n + 1) / 2)
         if self.diagonal:

--- a/src/condor/backends/element_mixin.py
+++ b/src/condor/backends/element_mixin.py
@@ -103,6 +103,8 @@ class BackendSymbolDataMixin:
     # cached? currently computed by actual backend...
 
     def __post_init__(self, *args, **kwargs):
+        if len(self.shape) == 0:
+            self.shape = (1, 1)
         n = self.shape[0]
         size = np.prod(self.shape)
         if self.symmetric:

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -8,6 +8,7 @@ import ndsplines
 import numpy as np
 
 from condor.backend import (
+    SymbolCompatibleDict,
     expression_to_operator,
     is_constant,
     process_relational_element,
@@ -521,9 +522,10 @@ class TrajectoryAnalysisType(SubmodelType):
 
         ode_model = new_cls._meta.primary
         model = new_cls
-        control_subs_pairs = {
-            control.backend_repr: [control.default] for control in ode_model.modal
-        }
+        control_subs_pairs = SymbolCompatibleDict()
+        for control in ode_model.modal:
+            control_subs_pairs[control.backend_repr] = [control.default]
+
         for mode in model._meta.modes:
             for act in mode.action:
                 control_subs_pairs[act.match.backend_repr].insert(

--- a/src/condor/contrib.py
+++ b/src/condor/contrib.py
@@ -1108,12 +1108,12 @@ class TableLookup(ExternalSolverWrapper):
         input_data = []
         for k, v in xx.items():
             self.input(name=k)
-            input_data.append(v)
+            input_data.append(np.array(v))
         output_data = []
         for k, v in yy.items():
             self.output(name=k)
             output_data.append(v)
-        output_data = np.stack(output_data, axis=-1)
+        output_data = np.array(np.stack(output_data, axis=-1))
         self.interpolant = ndsplines.make_interp_spline(
             input_data,
             output_data,

--- a/src/condor/fields.py
+++ b/src/condor/fields.py
@@ -99,7 +99,7 @@ class FieldValues:
                 for elem, v in zip(self.field, self.asdict().values())
             ]
         )
-        if not isinstance(flat_val, backend.symbol_class):
+        if not backend.is_symbol(flat_val):
             flat_val = np.array(flat_val).reshape(-1)
         return flat_val
 
@@ -271,7 +271,7 @@ class Field:
         # would be nice to be able to follow references, etc. can match be used?
         if len(args) == 1 and not kwargs:
             field_value = args[0]
-            if isinstance(field_value, backend.symbol_class):
+            if backend.symbol_is(field_value):
                 kwargs.update(backend_repr=field_value)
 
         items = []
@@ -281,8 +281,8 @@ class Field:
                 item_value = item
                 for field_name_comp in field_name.split("__"):
                     item_value = getattr(item_value, field_name_comp)
-                if isinstance(item_value, backend.symbol_class):
-                    if not isinstance(field_value, backend.symbol_class):
+                if backend.is_symbol(item_value):
+                    if not backend.is_symbol(field_value):
                         this_item = False
                         break
                     this_item = this_item and backend.symbol_is(item_value, field_value)
@@ -432,7 +432,7 @@ class BaseElement(
                 # TODO: how to DRY this up? also in MatchedElement.__hash__
                 # (adding match to hash)
                 self.backend_repr
-                if isinstance(self.backend_repr, backend.symbol_class)
+                if backend.is_symbol(self.backend_repr)
                 else tuple(np.array(self.backend_repr).flatten().tolist()),
                 self.shape,
                 self.field_type._name,
@@ -477,7 +477,7 @@ class BaseElement(
         if isinstance(other, self.__class__):
             # short circuit using is if it's the same type of element
             return self is other
-        if isinstance(other, backend.symbol_class):
+        if backend.is_symbol(other):
             return _generic_op(operator.eq)
         return super().__eq__(other)
 
@@ -612,7 +612,7 @@ class WithDefaultElement(FreeElement):
 class WithDefaultField(FreeField):
     def create_substitution_dict(self, subclass, set_attr=False):
         """ """
-        substitution_dict = {}
+        substitution_dict = backend.SymbolCompatibleDict()
         # TODO: no back reference is preserved which frankly seems harsh...
         for elem in self:
             log.debug("checking placeholder %s on %s", elem, subclass)
@@ -639,8 +639,8 @@ class WithDefaultField(FreeField):
             if set_attr:
                 setattr(subclass, elem.name, use_val)
             log.debug("creating substitution %s = %s", elem.backend_repr, use_val)
-            if isinstance(use_val, backend.symbol_class):
-                if elem.size >= np.prod(use_val.size()):
+            if backend.is_symbol(use_val):
+                if elem.size >= np.prod(use_val.size):
                     try:
                         np.broadcast_shapes(elem.shape, use_val.shape)
                     except ValueError:
@@ -703,7 +703,7 @@ class InitializedElement(BoundedElement):
         # TODO: test this behavior? lol
         if isinstance(self.initializer, BaseElement):
             self.initializer = np.ones(self.shape) * self.initializer.backend_repr
-        elif isinstance(self.initializer, backend.symbol_class):
+        elif backend.is_symbol(self.initializer):
             self.initializer = np.ones(self.shape) * self.initializer
         else:
             self.initializer = np.broadcast_to(self.initializer, self.shape)
@@ -756,12 +756,12 @@ class TrajectoryOutputField(FreeField, default_direction=Direction.output):
         if isinstance(integrand, BaseElement):
             integrand = integrand.backend_repr
 
-        if isinstance(terminal_term, backend.symbol_class):
+        if backend.is_symbol(terminal_term):
             # comstant terminal terms are handled below
             shape_data = backend.get_symbol_data(terminal_term)
             kwargs["terminal_term"] = terminal_term
 
-        if isinstance(integrand, backend.symbol_class):
+        if backend.is_symbol(integrand):
             if "terminal_term" in kwargs:
                 if backend.get_symbol_data(integrand) != shape_data:
                     # TODO would be nice to include the names here
@@ -820,7 +820,7 @@ class AssignedField(Field, default_direction=Direction.output):
             self._add_to_namespace = add_to_namespace_override
 
     def __setattr__(self, name, value):
-        if name.startswith("_") and not isinstance(value, backend.symbol_class):
+        if name.startswith("_") and not backend.is_symbol(value):
             # TODO: iirc the reason we need to prefix field attributes that are directly
             # assigned with _ is to allow this check to work, bypassing the creation of
             # a new element. Is it actually sufficient to just if the value is a
@@ -866,7 +866,7 @@ class MatchedElement(BaseElement, MatchedElementMixin):
                 # TODO: how to DRY this up? also in BaseElement.__hash__
                 # (adding match to hash)
                 self.backend_repr
-                if isinstance(self.backend_repr, backend.symbol_class)
+                if backend.is_symbol(self.backend_repr)
                 else tuple(np.array(self.backend_repr).flatten().tolist()),
                 self.match,
                 self.shape,
@@ -909,7 +909,7 @@ class MatchedField(Field):
             element.update_name()
 
     def key_to_matched_element(self, key):
-        if isinstance(key, backend.symbol_class):
+        if backend.is_symbol(key):
             match = self._matched_to.get(backend_repr=key)
             if isinstance(match, list):
                 msg = f"Could not find match for {key}"
@@ -941,7 +941,7 @@ class MatchedField(Field):
             else:
                 symbol_data = backend.get_symbol_data(value)
 
-                if isinstance(value, backend.symbol_class):
+                if backend.is_symbol(value):
                     backend_repr = value
                 else:
                     value = np.atleast_1d(value)

--- a/src/condor/implementations/iterative.py
+++ b/src/condor/implementations/iterative.py
@@ -482,9 +482,9 @@ class ScipyMinimizeBase(OptimizationProblem):
             )
 
         min_out = minimize(
-            lambda *args: self.f_func(*args).toarray().squeeze(),
+            lambda *args: self.f_func(*args).squeeze(),
             self.x0,
-            jac=lambda *args: self.f_jac_func(*args).toarray().squeeze(),
+            jac=lambda *args: self.f_jac_func(*args).squeeze(),
             method=self.method_string,
             args=extra_args,
             constraints=scipy_constraints,
@@ -539,7 +539,7 @@ class ScipySLSQP(ScipyMinimizeBase):
             self.con.append(
                 dict(
                     type="eq",
-                    fun=lambda x, p: self.eq_g_func(x, p).toarray().squeeze().T,
+                    fun=lambda x, p: self.eq_g_func(x, p).squeeze().T,
                     jac=self.eq_g_jac_func,
                 )
             )
@@ -559,7 +559,7 @@ class ScipySLSQP(ScipyMinimizeBase):
             self.con.append(
                 dict(
                     type="ineq",
-                    fun=lambda x, p: self.ineq_g_func(x, p).toarray().squeeze().T,
+                    fun=lambda x, p: self.ineq_g_func(x, p).squeeze().T,
                     jac=self.ineq_g_jac_func,
                 )
             )
@@ -682,10 +682,10 @@ class ScipyTrustConstr(ScipyMinimizeBase):
                 NonlinearConstraint(
                     fun=(
                         lambda *args: self.g_func(*args, *extra_args)
-                        .toarray()
+                        # .toarray()
                         .squeeze()
                     ),
-                    jac=(lambda *args: self.g_jac_func(*args, *extra_args).sparse()),
+                    jac=(lambda *args: self.g_jac_func(*args, *extra_args)),
                     lb=self.nonlinear_lb,
                     ub=self.nonlinear_ub,
                 )

--- a/src/condor/implementations/iterative.py
+++ b/src/condor/implementations/iterative.py
@@ -626,7 +626,7 @@ class ScipyTrustConstr(ScipyMinimizeBase):
                     for ub, is_nonlinear in zip(self.ubg, nonlinear_flags)
                     if is_nonlinear
                 ]
-            )
+            ).squeeze()
 
             self.nonlinear_lb = np.array(
                 [
@@ -634,7 +634,7 @@ class ScipyTrustConstr(ScipyMinimizeBase):
                     for lb, is_nonlinear in zip(self.lbg, nonlinear_flags)
                     if is_nonlinear
                 ]
-            )
+            ).squeeze()
 
         # process linear constraints
         linear_a_exprs = [

--- a/src/condor/implementations/iterative.py
+++ b/src/condor/implementations/iterative.py
@@ -7,6 +7,7 @@ from scipy.optimize import LinearConstraint, NonlinearConstraint, minimize
 import condor as co
 from condor.backend import (
     expression_to_operator,
+    is_symbol,
     symbol_class,
 )
 from condor.backend.operators import (
@@ -408,7 +409,7 @@ class CasadiNlpsolImplementation(OptimizationProblem):
         else:
             var_out = self.callback(run_p)
 
-        if isinstance(var_out, symbol_class):
+        if is_symbol(var_out):
             out = dict(
                 x=var_out,
                 p=run_p,
@@ -417,13 +418,14 @@ class CasadiNlpsolImplementation(OptimizationProblem):
                 lam_g=None,
                 lam_x=None,
             )
+            model_instance.objective = out["f"]
         else:
             out = self.callback.out
             model_instance._stats = self.callback._stats
+            model_instance.objective = np.array(out["f"]).squeeze()
 
         model_instance.bind_field(self.model.variable.wrap(out["x"]))
         model_instance.bind_field(self.model.constraint.wrap(out["g"]))
-        model_instance.objective = np.array(out["f"]).squeeze()
         self.out = out
         self.lam_g0 = out["lam_g"]
         self.lam_x0 = out["lam_x"]

--- a/src/condor/implementations/sgm_trajectory.py
+++ b/src/condor/implementations/sgm_trajectory.py
@@ -9,7 +9,7 @@ from condor import backend
 from condor.backend import (
     FunctionOperator,
     expression_to_operator,
-    symbol_class,
+    is_symbol,
 )
 from condor.backend.operators import (
     concat,
@@ -99,9 +99,8 @@ class TrajectoryAnalysis:
         ]
 
         self.traj_out_expr = model.trajectory_output.flatten()
-        self.can_sgm = isinstance(self.p, symbol_class) and isinstance(
-            self.traj_out_expr, symbol_class
-        )
+
+        self.can_sgm = is_symbol(self.p) and is_symbol(self.traj_out_expr)
 
         self.traj_out_integrand = model.trajectory_output.flatten("integrand")
         self.traj_out_integrand_func = expression_to_operator(
@@ -119,9 +118,10 @@ class TrajectoryAnalysis:
 
         self.state0 = get_state_setter(model.initial, [self.p])
 
-        control_subs_pairs = {
-            control.backend_repr: [control.default] for control in ode_model.modal
-        }
+        control_subs_pairs = backend.SymbolCompatibleDict()
+        for control in ode_model.modal:
+            control_subs_pairs[control.backend_repr] = [control.default]
+
         for mode in model._meta.modes:
             for act in mode.action:
                 control_subs_pairs[act.match.backend_repr].insert(
@@ -140,7 +140,7 @@ class TrajectoryAnalysis:
 
         if isinstance(model.t0, BaseElement):
             t0 = model.t0.backend_repr
-        elif isinstance(model.t0, (backend.symbol_class, float, np.ndarray)):
+        elif isinstance(model.t0, (float, np.ndarray)) or is_symbol(model.t0):
             t0 = model.t0
         else:
             unexpcted_t0 = "unexpected value for t0"
@@ -202,7 +202,7 @@ class TrajectoryAnalysis:
                     e_expr = mod(model.t - at_time_start, at_time.step)
 
                     # TODO: verify start and stop for at_time slice
-                    if isinstance(at_time_start, symbol_class) or at_time_start != 0.0:
+                    if is_symbol(at_time_start) or at_time_start != 0.0:
                         e_expr = e_expr * (model.t >= at_time_start)
                         # if there is a start offset, add a linear term to provide a
                         # zero-crossing at first occurance

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -812,7 +812,7 @@ def check_attr_name(attr_name, attr_val, new_cls):
         else:
             compare_attr_new = attr_val
 
-        if backend.symbol_is(compare_attr_existing):
+        if backend.is_symbol(compare_attr_existing):
             if backend.symbol_is(compare_attr_new, compare_attr_existing):
                 return
         elif compare_attr_new is compare_attr_existing:

--- a/src/condor/models.py
+++ b/src/condor/models.py
@@ -149,7 +149,7 @@ class BaseCondorClassDict(dict):
             for input_val in attr_val.input_kwargs.values():
                 if not can_embed:
                     break
-                if isinstance(input_val, backend.symbol_class):
+                if backend.is_symbol(input_val):
                     for input_sym in backend.symbols_in(input_val):
                         if input_sym not in self.meta.backend_repr_elements:
                             can_embed = False
@@ -164,7 +164,7 @@ class BaseCondorClassDict(dict):
                 attr_val.name = attr_name
         if isinstance(attr_val, BaseElement) and not attr_val.name:
             attr_val.name = attr_name
-        if isinstance(attr_val, backend.symbol_class):
+        if backend.is_symbol(attr_val):
             # from a FreeField
             element = self.meta.backend_repr_elements.get(attr_val, None)
             if element is not None:
@@ -425,7 +425,7 @@ class BaseModelType(type):
         # what about a Model(Template) that is being declared in the class boy?
         else:
             existing_attr = cls_dict.get(k, None)
-            if isinstance(v, backend.symbol_class):
+            if backend.is_symbol(v):
                 elem_matching_backend_repr = meta.backend_repr_elements.get(v, None)
             else:
                 elem_matching_backend_repr = None
@@ -437,7 +437,7 @@ class BaseModelType(type):
                     existing_attr = elem_matching_backend_repr.backend_repr
                     # assume cls dict assignment??
                 if (existing_attr is v) or (
-                    isinstance(existing_attr, backend.symbol_class)
+                    backend.is_symbol(existing_attr)
                     and backend.symbol_is(existing_attr, v)
                 ):
                     # only ensure that this is marked as inherited, don't need
@@ -464,7 +464,7 @@ class BaseModelType(type):
                     f"to {name}"
                 )
 
-            if isinstance(v, backend.symbol_class):
+            if backend.is_symbol(v):
                 original_v = v
                 v = base._meta.backend_repr_elements.get(v, v)
                 if isinstance(v, BaseElement) and v.field_type._name == "placeholder":
@@ -497,7 +497,7 @@ class BaseModelType(type):
                         name,
                     )
                     cls_dict[k] = v
-            elif isinstance(v, backend.symbol_class):
+            elif backend.is_symbol(v):
                 # TODO: check what hits this. Previously, time dummy variable. But I
                 # think that might be captured by placeholders now?
                 log.debug(
@@ -563,7 +563,8 @@ class BaseModelType(type):
     @classmethod
     def is_condor_attr(cls, k, v):
         return (
-            isinstance(v, (Field, BaseElement, backend.symbol_class))
+            isinstance(v, (Field, BaseElement))
+            or backend.is_symbol(v)
             or k in cls.reserved_words
         )
 
@@ -740,7 +741,7 @@ class BaseModelType(type):
         pass_attr = True
         if isinstance(attr_val, BaseElement):
             pass
-        if isinstance(attr_val, backend.symbol_class):
+        if backend.is_symbol(attr_val):
             element = new_cls._meta.backend_repr_elements.get(attr_val, None)
             if element is not None:
                 log.debug(
@@ -811,7 +812,7 @@ def check_attr_name(attr_name, attr_val, new_cls):
         else:
             compare_attr_new = attr_val
 
-        if isinstance(compare_attr_existing, backend.symbol_class):
+        if backend.symbol_is(compare_attr_existing):
             if backend.symbol_is(compare_attr_new, compare_attr_existing):
                 return
         elif compare_attr_new is compare_attr_existing:
@@ -1134,7 +1135,7 @@ class ModelType(BaseModelType):
     @classmethod
     def process_condor_attr(cls, attr_name, attr_val, new_cls):
         pass_super = True
-        if isinstance(attr_val, (backend.symbol_class, BaseElement)):
+        if isinstance(attr_val, BaseElement) or backend.is_symbol(attr_val):
             log.debug(
                 "ModelType is checking a backend_repr... %s, %s, %s, %s",
                 attr_name,
@@ -1257,7 +1258,7 @@ class ModelType(BaseModelType):
 
         for field in new_cls._meta.noninput_fields:
             for elem in field:
-                if isinstance(elem.backend_repr, backend.symbol_class):
+                if backend.is_symbol(elem.backend_repr):
                     elem.backend_repr = backend.operators.substitute(
                         elem.backend_repr, placeholder_assignment_dict
                     )
@@ -1459,12 +1460,8 @@ class Model(metaclass=ModelType):
         for field in fields:
             model_instance_field = getattr(self, field._name)
             model_instance_field_dict = dc.asdict(model_instance_field)
-            model_assignments.update(
-                {
-                    elem.backend_repr: val
-                    for elem, val in zip(field, model_instance_field_dict.values())
-                }
-            )
+            for elem, val in zip(field, model_instance_field_dict.values()):
+                model_assignments[elem.backend_repr] = val
 
         self.update_model_assignments(model_assignments)
 
@@ -1510,7 +1507,7 @@ class Model(metaclass=ModelType):
             bound_field = getattr(self, field._name)
             bound_field_dict = dc.asdict(bound_field)
             for k, v in bound_field_dict.items():
-                if not isinstance(v, backend.symbol_class):
+                if not backend.is_symbol(v):
                     embedded_model_kwargs[k] = v
                 else:
                     value_found = False
@@ -1537,7 +1534,7 @@ class Model(metaclass=ModelType):
         bound_embedded_model.bind_input_fields(**embedded_model_kwargs)
 
     def bind_output_as_embedded(self, parent_instance, bound_embedded_model):
-        assignment_updates = {}
+        assignment_updates = backend.SymbolCompatibleDict()
         for field in self._meta.output_fields:
             sym_bound_field = getattr(self, field._name)
             ran_bound_field = getattr(bound_embedded_model, field._name)
@@ -1548,17 +1545,13 @@ class Model(metaclass=ModelType):
                 # TODO: sym_bound_field_dict is really just list_of?
                 sym_bound_field_dict = dc.asdict(sym_bound_field)
                 ran_bound_field_dict = dc.asdict(ran_bound_field)
-                assignment_updates.update(
-                    {
-                        sym_val: ran_val
-                        for sym_val, ran_val in zip(
-                            sym_bound_field_dict.values(), ran_bound_field_dict.values()
-                        )
-                        if isinstance(sym_val, backend.symbol_class)
-                    }
-                )
-            elif isinstance(sym_bound_field, backend.symbol_class):
-                assignment_updates.update({sym_bound_field: ran_bound_field})
+                for sym_val, ran_val in zip(
+                    sym_bound_field_dict.values(), ran_bound_field_dict.values()
+                ):
+                    if backend.is_symbol(sym_val):
+                        assignment_updates[sym_val] = ran_val
+            elif backend.is_symbol(sym_bound_field):
+                assignment_updates[sym_bound_field] = ran_bound_field
             else:
                 raise ValueError
         return assignment_updates

--- a/src/condor/solvers/casadi_warmstart_wrapper.py
+++ b/src/condor/solvers/casadi_warmstart_wrapper.py
@@ -216,7 +216,7 @@ class CasadiNlpsolWarmstart(CasadiWarmstartWrapperBase, CasadiFunctionCallback):
             self.nlp_args,
             self.options,
         )
-        if not self.init_var.jacobian()(self.p, []).nnz():
+        if not casadi.jacobian(self.init_var(self.p), self.p).nnz():
             sym_x0 = self.init_var(np.zeros(self.p.shape))
         else:
             sym_x0 = self.init_var(self.p)
@@ -336,7 +336,7 @@ class CasadiRootfinderWarmstart(CasadiWarmstartWrapperBase, CasadiFunctionCallba
             self.options,
         )
 
-        if not self.init_var.jacobian()(self.p, []).nnz():
+        if not casadi.jacobian(self.init_var(self.p), self.p).nnz():
             sym_x0 = self.init_var(np.zeros(self.p.shape))
         else:
             sym_x0 = self.init_var(self.p)

--- a/src/condor/solvers/casadi_warmstart_wrapper.py
+++ b/src/condor/solvers/casadi_warmstart_wrapper.py
@@ -406,9 +406,14 @@ class CasadiIterationCallback(casadi.Callback):
         if n == "f":
             return casadi.Sparsity.dense(1)
         elif n in ("x", "lam_x"):
-            return self.nlpdict["x"].sparsity()
+            x = self.nlpdict["x"]
+            if isinstance(x, casadi.array):
+                x = x.to_casadi()
+            return x.sparsity()
         elif n in ("g", "lam_g"):
             g = self.nlpdict["g"]
+            if isinstance(g, casadi.array):
+                g = g.to_casadi()
             if not hasattr(g, "sparsity"):
                 return casadi.Sparsity.dense(np.atleast_2d(g).shape)
             return g.sparsity()

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -1107,7 +1107,8 @@ class TrajectoryAnalysis:
                 segment.t0
             )
         self.cached_output = (
-            self.terminal_terms(result.p, result.t[-1], result.x[-1]) + integral
+            self.terminal_terms(result.p, result.t[-1], result.x[-1]).squeeze()
+            + integral
         )
         return self.cached_output
 

--- a/src/condor/solvers/sweeping_gradient_method.py
+++ b/src/condor/solvers/sweeping_gradient_method.py
@@ -1217,6 +1217,7 @@ class SweepingGradientMethod:
                     time_data,
                     integrand_data,
                     # bc_type=["natural", "natural"],
+                    k=min(3, len(time_data) - 1),
                 )
                 integrand_antider = integrand_interp.antiderivative()
                 jac_row += integrand_antider(time_data[-1]) - integrand_antider(

--- a/tests/modules/configured_model.py
+++ b/tests/modules/configured_model.py
@@ -32,7 +32,10 @@ class LTI(co.ODESystem):
             u = -K @ x
             dynamic_output.u = u
 
-        xdot += b @ u
+        if b.shape[-1] == 1:
+            xdot += b * u
+        else:
+            xdot += b @ u
 
     if not (settings["dt_plant"] and settings["dt"]):
         dot[x] = xdot

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -225,9 +225,12 @@ def test_external_jacobian(output_mode, models):
     out_jac = Jac(**kwargs)
     for output_ in Condoric.output:
         for input_ in Jac.input:
-            assert np.all(
-                getattr(out_jac, f"nsys_d{output_.name}_d{input_.name}")
-                == getattr(out_jac, f"csys_d{output_.name}_d{input_.name}")
+            assert getattr(
+                out_jac, f"nsys_d{output_.name}_d{input_.name}"
+            ) == pytest.approx(
+                getattr(out_jac, f"csys_d{output_.name}_d{input_.name}"),
+                abs=1e-18,
+                rel=1e-15,
             )
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -67,7 +67,7 @@ class CondoricMisc(condor.ExplicitSystem):
 
 def simple_rot(th, axis):
     non_axis = [i for i in range(3) if i != axis]
-    if isinstance(th, backend.symbol_class):
+    if backend.is_symbol(th):
         dcm = ops.zeros((3, 3))
     else:
         dcm = np.zeros((3, 3))
@@ -225,12 +225,9 @@ def test_external_jacobian(output_mode, models):
     out_jac = Jac(**kwargs)
     for output_ in Condoric.output:
         for input_ in Jac.input:
-            assert getattr(
-                out_jac, f"nsys_d{output_.name}_d{input_.name}"
-            ) == pytest.approx(
-                getattr(out_jac, f"csys_d{output_.name}_d{input_.name}"),
-                abs=1e-18,
-                rel=1e-15,
+            assert np.all(
+                getattr(out_jac, f"nsys_d{output_.name}_d{input_.name}")
+                == getattr(out_jac, f"csys_d{output_.name}_d{input_.name}")
             )
 
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -58,9 +58,9 @@ def test_diff():
 
     x = rng.random((5, 7))
     test_diff = TestDiff(x)
-    assert test_diff.y == pytest.approx(np.diff(x, axis=-1))
-    assert test_diff.z == pytest.approx(np.diff(x, axis=1))
-    assert test_diff.w == pytest.approx(np.diff(x, axis=0))
+    assert np.all(test_diff.y == np.diff(x, axis=-1))
+    assert np.all(test_diff.z == np.diff(x, axis=1))
+    assert np.all(test_diff.w == np.diff(x, axis=0))
 
 
 def test_prod():

--- a/tests/test_trajectory_analysis.py
+++ b/tests/test_trajectory_analysis.py
@@ -64,8 +64,8 @@ def test_ct_lqr():
     # continuous-time LQR
 
     class DblInt(co.ODESystem):
-        A = np.array([[0.0, 1.0], [0.0, 0.0]])
-        B = np.array([[0.0], [1.0]])
+        A = ops.array([[0.0, 1.0], [0.0, 0.0]])
+        B = ops.array([[0.0], [1.0]])
 
         K = parameter(shape=(1, B.shape[0]))
 
@@ -110,8 +110,8 @@ def test_ct_lqr():
 @pytest.mark.skip(reason="Need to fix LTI function")
 def test_sp_lqr():
     # sampled LQR
-    dblint_a = np.array([[0, 1], [0, 0]])
-    dblint_b = np.array([[0], [1]])
+    dblint_a = ops.array([[0, 1], [0, 0]])
+    dblint_b = ops.array([[0], [1]])
     dt = 0.5
 
     DblIntSampled = co.LTI(  # noqa: N806
@@ -191,8 +191,8 @@ def test_time_switched():
     # optimal transfer time with time-based events
 
     class DblInt(co.ODESystem):
-        a = np.array([[0, 1], [0, 0]])
-        b = np.array([[0], [1]])
+        a = ops.array([[0, 1], [0, 0]])
+        b = ops.array([[0], [1]])
 
         x = state(shape=a.shape[0])
         mode = state()
@@ -268,8 +268,8 @@ def test_state_switched():
     # optimal transfer time with state-based events
 
     class DblInt(co.ODESystem):
-        a = np.array([[0, 1], [0, 0]])
-        b = np.array([[0], [1]])
+        a = ops.array([[0, 1], [0, 0]])
+        b = ops.array([[0], [1]])
 
         x = state(shape=a.shape[0])
 
@@ -300,7 +300,7 @@ def test_state_switched():
 
     class Transfer(DblInt.TrajectoryAnalysis):
         initial[x] = [-9.0, 0.0]
-        xd = [1.0, 2.0]
+        xd = ops.array([1.0, 2.0]).reshape((2, 1))
         q = np.eye(2)
         cost = trajectory_output(((x - xd).T @ (x - xd)) / 2)
         tf = 20.0


### PR DESCRIPTION
Casadi 3.8 introduces an ArrayInterface class which handles much of the numpy compatibility issues. This PR attempts update the backend to use ArrayInterface instances for symbolic expressions rather than raw MX objects to simplify the condor code base for performance and maintainability.

- ended up changing the symbol generating algorithm to generate flat symbols, wrap with array, then reshape appropriately; this seems straightforward to get right and may enable support for higher dimensional expressions

- currently a bug in casadi that causes incorrect behavior for matrix multiply of ArrayInterface objects with numpy arrays; to get tests to pass and documentation to build, model expressions using numpy arrays are changed to use casadi arrays through the backend shim. We need to decide if this is desirable; I could imagine backend-specific numerical storage could be more efficient but I am not sure that this API can be used to specify anything other than dense matrices so there may not be a purpose except consistency of using the shim. If this is undesired, a new issue should be made to track casadi release and revert the examples back.
    - UPDATE (9/4/2026 1400): based on offline discussion probably OK to user `ops.array`, especially if we can use it to make other things nicer like supporting construction of arrays using a mix of casadi.MX (wrapped in array or not) and numeric literals 

- due to better `is_symbolic` checking, it may handle models with inputs from ops creation routines (eye/ones/etc) as numeric (correctly), should add test
    - UPDATE (9/4/2026 1400): initial tests don't work, probably worth fixing as part of this PR
 

- UPDATE (9/4/2026 1400): also interested in exploring additional wrapping on `expression_to_operator` to do substitutions if possible
    - UPDATE (9/4/2026 2230): benchmarked by running pytest, this is a substantial slowdown. It's possible it could have a positive impact on *coding* SIGMA, but maybe it's too much technical debt at this point? 